### PR TITLE
Centralizing and cleaning error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "http-status-codes": "^1.3.0",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
-    "mongodb": "^3.0.1",
     "mongoose": "^4.13.7",
     "multer": "^1.3.0",
     "sqlite": "^2.9.1",

--- a/src/middleware/objectid.validator.ts
+++ b/src/middleware/objectid.validator.ts
@@ -2,12 +2,12 @@ import * as express from 'express';
 import * as mongoose from 'mongoose';
 import * as HttpStatus from 'http-status-codes';
 import * as _ from 'lodash';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 
 export function validateObjectId(req: express.Request, _res: express.Response, next: express.NextFunction) {
 	const id = _.get(req, 'params.id');
 	if (id && !mongoose.Types.ObjectId.isValid(id)) {
-		return next(new ExpressError('Invalid Id', 'The Id specified is invalid', HttpStatus.BAD_REQUEST));
+		return next(new ExpressError('The Id specified is invalid', HttpStatus.BAD_REQUEST));
 	}
 
 	next();

--- a/src/middleware/require.json.ts
+++ b/src/middleware/require.json.ts
@@ -1,10 +1,10 @@
 import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 
 export default function requireJSON(req: express.Request, _res: express.Response, next: express.NextFunction) {
 	if (!req.is('json')) {
-		next(new ExpressError('Unsupported media type', 'The request must be a JSON object', HttpStatus.UNSUPPORTED_MEDIA_TYPE));
+		next(new ExpressError('The request must be a JSON object', HttpStatus.UNSUPPORTED_MEDIA_TYPE));
 	} else {
 		next();
 	}

--- a/src/routes/movement.ts
+++ b/src/routes/movement.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 import { MovementService } from '../services/movement';
 import BaseRouter from './base';
 import requireJSON from '../middleware/require.json';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 
 export class MovementRouter extends BaseRouter {
 	public path: string = 'movements';
@@ -50,7 +50,7 @@ export class MovementRouter extends BaseRouter {
 		try {
 			const data = await this.movementService.getMovement(userId, movementId);
 			if (!data) {
-				throw new ExpressError('404 Not found', 'Movement not found', HttpStatus.NOT_FOUND);
+				throw new ExpressError('Movement not found', HttpStatus.NOT_FOUND);
 			}
 
 			return res.send({

--- a/src/routes/my.wod.ts
+++ b/src/routes/my.wod.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as multer from 'multer';
 import * as HttpStatus from 'http-status-codes';
 
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 import BaseRouter from './base';
 import { MyWodService } from '../services/my.wod';
 import { UserSerializer } from '../utils/serialization/user.serializer';
@@ -33,7 +33,7 @@ export default class MywodRouter extends BaseRouter {
 		const file = req.file;
 		try {
 			if (!file) {
-				throw new ExpressError('Bad request', 'The form contains no file', HttpStatus.BAD_REQUEST);
+				throw new ExpressError('The form contains no file', HttpStatus.BAD_REQUEST);
 			}
 
 			const contents = await this.mywodService.readContentsFromDatabase(file.filename);

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -4,7 +4,7 @@ import * as bodyParser from 'body-parser';
 
 import BaseRouter from './base';
 import { UserService } from '../services/user';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 import { UserSerializer } from '../utils/serialization/user.serializer';
 
 export class UserRouter extends BaseRouter {
@@ -33,7 +33,7 @@ export class UserRouter extends BaseRouter {
 			const user = await this.userService.getUser(req['user']);
 
 			if (!user) {
-				throw new ExpressError('Not found', 'No user found with this email or password', HttpStatus.NOT_FOUND);
+				throw new ExpressError('No user found with this email or password', HttpStatus.NOT_FOUND);
 			}
 
 			return res.status(HttpStatus.OK).json({

--- a/src/routes/workout.ts
+++ b/src/routes/workout.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 import { WorkoutService } from '../services/workout';
 import BaseRouter from './base';
 import requireJSON from '../middleware/require.json';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 
 export default class WorkoutRouter extends BaseRouter {
 	public path: string = 'workouts';
@@ -50,7 +50,7 @@ export default class WorkoutRouter extends BaseRouter {
 		try {
 			const data = await this.workoutService.getWorkout(userId, workoutId);
 			if (!data) {
-				throw new ExpressError('404 Not found', 'Workout not found', HttpStatus.NOT_FOUND);
+				throw new ExpressError('Workout not found', HttpStatus.NOT_FOUND);
 			}
 
 			return res.send({

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose';
 import * as HttpStatus from 'http-status-codes';
 import { UserModel, UserType } from '../models/user';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 
 export class AuthService {
 	private userModel: mongoose.Model<UserType>;
@@ -20,11 +20,11 @@ export class AuthService {
 		const data = await this.userModel.findOne({ email });
 
 		if (!data) {
-			throw new ExpressError('Unauthorized', 'Email not registered', HttpStatus.UNAUTHORIZED);
+			throw new ExpressError('Email not registered', HttpStatus.UNAUTHORIZED);
 		}
 
 		if (data.password !== password) {
-			throw new ExpressError('Unauthorized', 'Password is incorrect', HttpStatus.UNAUTHORIZED);
+			throw new ExpressError('Password is incorrect', HttpStatus.UNAUTHORIZED);
 		}
 
 		return data;

--- a/src/services/movement.ts
+++ b/src/services/movement.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose';
 import * as HttpStatus from 'http-status-codes';
 import { MovementModel, MovementType } from '../models/movement';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 import { MovementScoreType, MovementScoreModel } from '../models/movement.score';
 import { QueryUtils } from '../utils/query.utils';
 
@@ -25,7 +25,7 @@ export class MovementService {
 	async getMovementScores(userId: string, movementId: string) {
 		const movement = await this.getMovement(userId, movementId);
 		if (!movement) {
-			throw new ExpressError('Object not found', `Entity with identity '${movementId}' does not exist`, HttpStatus.NOT_FOUND);
+			throw new ExpressError(`Entity with identity '${movementId}' does not exist`, HttpStatus.NOT_FOUND);
 		}
 		return this.movementScoreModel.find(QueryUtils.forOne({ 'movementId': movementId }, userId));
 	}
@@ -39,7 +39,7 @@ export class MovementService {
 		const movementModel = await this.getMovement(userId, movementId);
 
 		if (!movementModel) {
-			throw new ExpressError('Object not found', `Entity with identity '${movementId}' does not exist`, HttpStatus.NOT_FOUND);
+			throw new ExpressError(`Entity with identity '${movementId}' does not exist`, HttpStatus.NOT_FOUND);
 		}
 
 		score.movementId = movementModel.id;

--- a/src/services/my.wod.ts
+++ b/src/services/my.wod.ts
@@ -10,7 +10,7 @@ import { WorkoutModel, WorkoutType } from '../models/workout';
 import { MovementModel, MovementType } from '../models/movement';
 import { MovementScoreModel, MovementScoreType } from '../models/movement.score';
 import { WorkoutScoreModel, WorkoutScoreType } from '../models/workout.score';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 import { MyWodUtils } from '../utils/my.wod.utils';
 import { Logger } from '../utils/logger/logger';
 import { WorkoutService } from './workout';
@@ -38,13 +38,13 @@ export class MyWodService {
 
 	public async saveAthlete(user: any, data: any) {
 		if (data.email !== user.email) {
-			throw new ExpressError('Emails do not match', 'This myWOD backup does not belong to this email address', HttpStatus.FORBIDDEN);
+			throw new ExpressError('This myWOD backup does not belong to this email address', HttpStatus.FORBIDDEN);
 		}
 
 		let model = await this.userModel.findOne({ email: user.email });
 
 		if (!model) {
-			throw new ExpressError('Not found', 'Could not detect a user logged in', HttpStatus.NOT_FOUND);
+			throw new ExpressError('Could not detect a user logged in', HttpStatus.NOT_FOUND);
 		}
 
 		model = this.updateUser(model, data);

--- a/src/services/workout.ts
+++ b/src/services/workout.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose';
 import * as HttpStatus from 'http-status-codes';
 import { WorkoutModel, WorkoutType } from '../models/workout';
-import ExpressError from '../utils/express.error';
+import { ExpressError } from '../utils/express.error';
 import { WorkoutScoreType, WorkoutScoreModel } from '../models/workout.score';
 import { QueryUtils } from '../utils/query.utils';
 
@@ -29,7 +29,7 @@ export class WorkoutService {
 	async getWorkoutScores(userId: string, workoutId: string) {
 		const workout = await this.getWorkout(userId, workoutId);
 		if (!workout) {
-			throw new ExpressError('Object not found', `Entity with identity '${workoutId}' does not exist`, HttpStatus.NOT_FOUND);
+			throw new ExpressError(`Entity with identity '${workoutId}' does not exist`, HttpStatus.NOT_FOUND);
 		}
 		return this.workoutScoreModel.find(QueryUtils.forOne({ 'workoutId': workoutId }, userId));
 	}
@@ -43,7 +43,7 @@ export class WorkoutService {
 		const workoutModel = await this.getWorkout(userId, workoutId);
 
 		if (!workoutModel) {
-			throw new ExpressError('Object not found', `Entity with identity '${workoutId}' does not exist`, HttpStatus.NOT_FOUND);
+			throw new ExpressError(`Entity with identity '${workoutId}' does not exist`, HttpStatus.NOT_FOUND);
 		}
 
 		score.createdBy = userId;

--- a/src/utils/error.utils.ts
+++ b/src/utils/error.utils.ts
@@ -1,0 +1,97 @@
+import * as HttpStatus from 'http-status-codes';
+import { ExpressError } from '../utils/express.error';
+
+const MONGO_ERROR_DUPLICATE_KEY_ON_INSERT = 11000;
+const MONGO_ERROR_DUPLICATE_KEY_ON_UPDATE = 11001;
+const MONGO_ERROR_KEY_TOO_LONG = 17280;
+
+export class ErrorUtils {
+	/**
+	 * Used by the JSON API Serializer. Makes sure
+	 * that we do not return any non ExpressErrors
+	 * to the client.
+	 *
+	 * @param err any type of error
+	 */
+	public static ensureExpressError(err: any): ExpressError | ExpressError[] {
+		err = err || {};
+		if (ErrorUtils.isExpressError(err)) {
+			return err;
+		}
+
+		if (ErrorUtils.isErrorWithErrors(err)) {
+			return ErrorUtils.convertMongooseErrorToExpressErrors(err);
+		}
+
+		if (err.code) {
+			return ErrorUtils.convertMongoErrorToExpressError(err);
+		}
+		const msg = err.message || 'Unknown error occurred';
+		const status = err.status || HttpStatus.INTERNAL_SERVER_ERROR;
+		return new ExpressError(msg, status);
+	}
+
+	/**
+	 * This method convert a MongoError to an ExpressError when an error is thrown from MongoDB
+	 * It will just return it untouched if we are not reading these specific mongo error codes.
+	 * For a complete list of mongo error codes see: https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
+	 *
+	 * @param err the error assumed to be from MongoDB
+	 */
+	public static convertMongoErrorToExpressError(err: any) {
+		let code = HttpStatus.INTERNAL_SERVER_ERROR;
+		let msg = err.message || 'Unknown Mongo error occurred';
+		switch (err.code) {
+			case MONGO_ERROR_DUPLICATE_KEY_ON_INSERT:
+			case MONGO_ERROR_DUPLICATE_KEY_ON_UPDATE:
+				msg = 'A Resource with the same unique identity already exists';
+				code = HttpStatus.CONFLICT;
+				break;
+			case MONGO_ERROR_KEY_TOO_LONG:
+				msg = 'A value for an indexed property can be at most 1024 bytes in size';
+				code = HttpStatus.UNPROCESSABLE_ENTITY;
+				break;
+			default:
+				break;
+		}
+		return new ExpressError(msg, code);
+	}
+
+	/**
+	 * Mongoose errors are formatted as an array of errors. Use this
+	 * function to clean up the returned error by setting a status
+	 * code and using the message from each error as the detail msg.
+	 *
+	 * @param mongooseErrors an object with error names as the key and the error as their values
+	 * @param status status code to set on the ExpressError
+	 */
+	public static convertMongooseErrorToExpressErrors(mongooseErrors: { errors: { [key: string]: Error } }) {
+		const errorObject = mongooseErrors.errors;
+		return Object.keys(errorObject).map((key: string) => {
+			const err = errorObject[key];
+			const status = ErrorUtils.guessStatusCode(err);
+			return new ExpressError(err.message, status);
+		});
+	}
+
+	// #region helper utilities
+	public static guessStatusCode(err: any) {
+		let status = HttpStatus.INTERNAL_SERVER_ERROR;
+		if (err.$isValidatorError) {
+			status = HttpStatus.UNPROCESSABLE_ENTITY;
+		}
+		return status;
+	}
+
+	public static isExpressError(err: any) {
+		if (Array.isArray(err)) {
+			err = err[0];
+		}
+		return err instanceof ExpressError;
+	}
+
+	public static isErrorWithErrors(error: any) {
+		return Boolean(error && error.errors);
+	}
+	//#endregion
+}

--- a/src/utils/express.error.ts
+++ b/src/utils/express.error.ts
@@ -1,6 +1,9 @@
+import * as HttpStatus from 'http-status-codes';
 
-export default class ExpressError extends Error {
-	constructor(public title: string, public detail: string, public status: number) {
-		super(title);
+export class ExpressError extends Error {
+	public title: string;
+	constructor(public detail: string, public status: number) {
+		super(HttpStatus.getStatusText(status));
+		this.title = `${status} ${this.message}`;
 	}
 }

--- a/tests/middleware/objectid.validator.spec.ts
+++ b/tests/middleware/objectid.validator.spec.ts
@@ -1,5 +1,5 @@
 import * as HttpStatus from 'http-status-codes';
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 import { validateObjectId } from '../../src/middleware/objectid.validator';
 
 describe('validateObjectId', () => {
@@ -48,6 +48,6 @@ describe('validateObjectId', () => {
 		validateObjectId(req, res, _next);
 
 		expect(_next).toHaveBeenCalledTimes(1);
-		expect(_next).toBeCalledWith(new ExpressError('Invalid Id', 'The Id specified is not valid', HttpStatus.BAD_REQUEST));
+		expect(_next).toBeCalledWith(new ExpressError('The Id specified is not valid', HttpStatus.BAD_REQUEST));
 	});
 });

--- a/tests/routes/movement.spec.ts
+++ b/tests/routes/movement.spec.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 
 import { MovementRouter } from '../../src/routes/movement';
 import { MovementService } from '../../src/services/movement';
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 import RouterUtils from '../../src/utils/router.utils';
 
 describe('Movement endpoint', () => {
@@ -192,7 +192,7 @@ describe('Movement endpoint', () => {
 		});
 
 		it('should return 404 if the specified movement does not exist', async (done) => {
-			const err = new ExpressError('Object not found', `Entity with identity '${movementMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${movementMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_movementService.expects('getMovementScores').withExactArgs(user.id, movementMongo.id).throws(err);
 
 			try {
@@ -226,7 +226,7 @@ describe('Movement endpoint', () => {
 		});
 
 		it('should return 404 if the specified movement does not exist', async (done) => {
-			const err = new ExpressError('Object not found', `Entity with identity '${movementMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${movementMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_movementService.expects('addScore').withExactArgs(user.id, movementMongo.id, score).rejects(err);
 
 			try {

--- a/tests/routes/workout.spec.ts
+++ b/tests/routes/workout.spec.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 
 import WorkoutRouter from '../../src/routes/workout';
 import { WorkoutService } from '../../src/services/workout';
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 import RouterUtils from '../../src/utils/router.utils';
 
 describe('Workout endpoint', () => {
@@ -196,7 +196,7 @@ describe('Workout endpoint', () => {
 		});
 
 		it('should return 404 if the specified workout does not exist', async (done) => {
-			const err = new ExpressError('Object not found', `Entity with identity '${workoutMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${workoutMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_workoutService.expects('getWorkoutScores').withExactArgs(user.id, workoutMongo.id).throws(err);
 
 			try {
@@ -230,7 +230,7 @@ describe('Workout endpoint', () => {
 		});
 
 		it('should return 404 if the specified workout does not exist', async (done) => {
-			const err = new ExpressError('Object not found', `Entity with identity '${workoutMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${workoutMongo.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_workoutService.expects('addScore').withExactArgs(user.id, workoutMongo.id, score).rejects(err);
 
 			try {

--- a/tests/services/auth.spec.ts
+++ b/tests/services/auth.spec.ts
@@ -1,7 +1,6 @@
 import * as sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
 
-import ExpressError from '../../src/utils/express.error';
 import { AuthService } from '../../src/services/auth';
 import { UserType } from '../../src/models/user';
 
@@ -60,54 +59,38 @@ describe('AuthService', () => {
 	});
 
 	describe('register', () => {
-		it('should register a user successfully', async (done) => {
-			try {
-				_modelInstance.expects('save').resolves(data);
+		it('should register a user successfully', async () => {
+			_modelInstance.expects('save').resolves(data);
 
-				const res = await service.register(data);
-				expect(res).toEqual(data);
-				done();
-			} catch (err) {
-				done(err);
-			}
+			const promise = service.register(data);
+			await expect(promise).resolves.toEqual(data);
+			verifyAll();
 		});
 	});
 
 	describe('login', () => {
-		it('should successfully login if user exists', async (done) => {
-			try {
-				_model.expects('findOne').withArgs({ email: data.email }).resolves(data);
+		it('should successfully login if user exists', async () => {
+			_model.expects('findOne').withArgs({ email: data.email }).resolves(data);
 
-				const res = await service.login(data);
-				expect(res).toEqual(data);
-				done();
-			} catch (err) {
-				done(err);
-			}
+			const promise = service.login(data);
+			await expect(promise).resolves.toEqual(data);
+			verifyAll();
 		});
 
-		it('should throw unauthorized exception if user does not exist', async (done) => {
-			try {
-				_model.expects('findOne').resolves();
+		it('should throw unauthorized exception if user does not exist', async () => {
+			_model.expects('findOne').resolves();
 
-				const promise = service.login(data);
-				await expect(promise).rejects.toHaveProperty('status', HttpStatus.UNAUTHORIZED);
-				done();
-			} catch (err) {
-				done(err);
-			}
+			const promise = service.login(data);
+			await expect(promise).rejects.toHaveProperty('status', HttpStatus.UNAUTHORIZED);
+			verifyAll();
 		});
 
-		it('should throw unauthorized exception if user exists but password does not match', async (done) => {
-			try {
-				_model.expects('findOne').resolves({ email: data.email, password: 'anotherPassword' });
+		it('should throw unauthorized exception if user exists but password does not match', async () => {
+			_model.expects('findOne').resolves({ email: data.email, password: 'anotherPassword' });
 
-				const promise = service.login(data);
-				await expect(promise).rejects.toHaveProperty('status', HttpStatus.UNAUTHORIZED);
-				done();
-			} catch (err) {
-				done(err);
-			}
+			const promise = service.login(data);
+			await expect(promise).rejects.toHaveProperty('status', HttpStatus.UNAUTHORIZED);
+			verifyAll();
 		});
 	});
 });

--- a/tests/services/movement.spec.ts
+++ b/tests/services/movement.spec.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
 import * as sqlite from 'sqlite';
 
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 import { MovementService } from '../../src/services/movement';
 import { MovementScoreType } from '../../src/models/movement.score';
 import { MovementType } from '../../src/models/movement';
@@ -121,7 +121,7 @@ describe('MovementService', () => {
 		});
 
 		it('should throw error if movement does not exist', async () => {
-			const err = new ExpressError('Object not found', `Entity with identity '${movement.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${movement.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_service.expects('getMovement').withExactArgs(user.id, movement.id).resolves(null);
 
 			const promise = service.getMovementScores(user.id, movement.id);

--- a/tests/services/my.wod.spec.ts
+++ b/tests/services/my.wod.spec.ts
@@ -4,9 +4,7 @@ import * as sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
 import * as sqlite from 'sqlite';
 
-import ExpressError from '../../src/utils/express.error';
 import { MyWodService } from '../../src/services/my.wod';
-import { MongoError } from 'mongodb';
 import { WorkoutService } from '../../src/services/workout';
 
 describe('MywodService', () => {

--- a/tests/services/user.spec.ts
+++ b/tests/services/user.spec.ts
@@ -1,7 +1,6 @@
 import * as sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
 
-import ExpressError from '../../src/utils/express.error';
 import { UserService } from '../../src/services/user';
 
 describe('UserService', () => {

--- a/tests/services/workout.spec.ts
+++ b/tests/services/workout.spec.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
 
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 import { WorkoutService } from '../../src/services/workout';
 import { QueryUtils } from '../../src/utils/query.utils';
 
@@ -104,7 +104,7 @@ describe('WorkoutService', () => {
 
 	describe('getWorkoutByTitle', () => {
 		it('should query model by workout title', async () => {
-			_model.expects('findOne').withArgs(QueryUtils.forOne({'title': workout.title}, user.id)).returns(workout);
+			_model.expects('findOne').withArgs(QueryUtils.forOne({ 'title': workout.title }, user.id)).returns(workout);
 
 			const res = await service.getWorkoutByTitle(workout.title, user.id);
 			expect(res).toEqual(workout);
@@ -123,7 +123,7 @@ describe('WorkoutService', () => {
 		});
 
 		it('should throw error if workout does not exist', async () => {
-			const err = new ExpressError('Object not found', `Entity with identity '${workout.id}' does not exist`, HttpStatus.NOT_FOUND);
+			const err = new ExpressError(`Entity with identity '${workout.id}' does not exist`, HttpStatus.NOT_FOUND);
 			_service.expects('getWorkout').withExactArgs(user.id, workout.id).resolves(null);
 
 			const promise = service.getWorkoutScores(user.id, workout.id);

--- a/tests/utils/error.utils.spec.ts
+++ b/tests/utils/error.utils.spec.ts
@@ -1,0 +1,188 @@
+import * as HttpStatus from 'http-status-codes';
+import { ErrorUtils } from '../../src/utils/error.utils';
+import { ExpressError } from '../../src/utils/express.error';
+import { Error } from 'mongoose';
+
+describe('ErrorUtils', () => {
+	describe('ensureExpressError', () => {
+		it('should return ExpressError as is', () => {
+			const exprErr = new ExpressError('msg', HttpStatus.IM_A_TEAPOT);
+			const res = ErrorUtils.ensureExpressError(exprErr);
+			expect(res).toEqual(exprErr);
+		});
+
+		it('should return array of express errors if the error contains a truthy errors property', () => {
+			const manyErrors = {
+				'errors': {
+					'key1': {
+						'name': 'errName1',
+						'message': 'errMessage1',
+						'$isValidatorError': true
+					},
+					'key2': {
+						'name': 'errName2',
+						'message': 'errMessage2',
+						'$isValidatorError': false
+					}
+				}
+			};
+			const res = ErrorUtils.ensureExpressError(manyErrors);
+			expect(res).toHaveProperty('length', 2);
+			expect(res[0]).toBeInstanceOf(ExpressError);
+			expect(res[1]).toBeInstanceOf(ExpressError);
+		});
+
+		it('should convert Mongo error if error has a truthy code property', () => {
+			const err = { name: 'MongoError', code: 11000 };
+			const res = ErrorUtils.ensureExpressError(err);
+			expect(res).toHaveProperty('status', HttpStatus.CONFLICT);
+			expect(res).toBeInstanceOf(ExpressError);
+		});
+
+		it('should use information from the error if cases are not known', () => {
+			const err = { message: 'test', status: HttpStatus.BAD_REQUEST };
+			const res = ErrorUtils.ensureExpressError(err);
+			expect(res).toHaveProperty('detail', err.message);
+			expect(res).toHaveProperty('status', HttpStatus.BAD_REQUEST);
+			expect(res).toBeInstanceOf(ExpressError);
+		});
+
+		it('should use default text and code if error is falsy', () => {
+			const res = ErrorUtils.ensureExpressError(null);
+			expect(res).toHaveProperty('detail', 'Unknown error occurred');
+			expect(res).toHaveProperty('status', HttpStatus.INTERNAL_SERVER_ERROR);
+			expect(res).toBeInstanceOf(ExpressError);
+		});
+	});
+
+	describe('convertMongoErrorToExpressError', () => {
+		it('should convert MongoError with code 11000 to ExpressError with status 409 Conflict', () => {
+			const err = { name: 'MongoError', code: 11000 };
+			const res = ErrorUtils.convertMongoErrorToExpressError(err);
+			expect(res).toHaveProperty('status', HttpStatus.CONFLICT);
+		});
+
+		it('should convert MongoError with code 11001 to ExpressError with status 409 Conflict', () => {
+			const err = { name: 'MongoError', code: 11001 };
+			const res = ErrorUtils.convertMongoErrorToExpressError(err);
+			expect(res).toHaveProperty('status', HttpStatus.CONFLICT);
+		});
+
+		it('should convert MongoError with code 17280 to ExpressError with status 422 Unprocessable Entity', () => {
+			const err = { name: 'MongoError', code: 17280 };
+			const res = ErrorUtils.convertMongoErrorToExpressError(err);
+			expect(res).toHaveProperty('status', HttpStatus.UNPROCESSABLE_ENTITY);
+		});
+
+		it('should create ExpressError with information from the MongoError in cases that are not known', () => {
+			const err = { name: 'MongoError', message: 'test' };
+			const res = ErrorUtils.convertMongoErrorToExpressError(err);
+			expect(res).toHaveProperty('detail', err.message);
+			expect(res).toHaveProperty('status', HttpStatus.INTERNAL_SERVER_ERROR);
+		});
+
+		it('should create ExpressError with default text and 500 Server Error code if nothing can be extracted from the error', () => {
+			const err = { name: 'MongoError' };
+			const res = ErrorUtils.convertMongoErrorToExpressError(err);
+			expect(res).toHaveProperty('detail', 'Unknown Mongo error occurred');
+			expect(res).toHaveProperty('status', HttpStatus.INTERNAL_SERVER_ERROR);
+		});
+	});
+
+	describe('convertMongooseErrorToExpressErrors', () => {
+		it('should convert mongoose errors to list of ExpressError', () => {
+			const mongooseErrors = {
+				'errors': {
+					'key1': {
+						'name': 'errName1',
+						'message': 'errMessage1',
+						'$isValidatorError': true
+					},
+					'key2': {
+						'name': 'errName2',
+						'message': 'errMessage2',
+						'$isValidatorError': false
+					}
+				}
+			};
+
+			const res = ErrorUtils.convertMongooseErrorToExpressErrors(mongooseErrors);
+			expect(res).toBeDefined();
+			expect(res.length).toEqual(2);
+			expect(res[0].detail).toEqual(mongooseErrors.errors.key1.message);
+			expect(res[0].status).toEqual(HttpStatus.UNPROCESSABLE_ENTITY);
+			expect(res[1].detail).toEqual(mongooseErrors.errors.key2.message);
+			expect(res[1].status).toEqual(HttpStatus.INTERNAL_SERVER_ERROR);
+		});
+	});
+
+	describe('guessStatusCode', () => {
+		it('should return 422 Unprocessable Entity if error is a ValidatorError', () => {
+			const err = {
+				'$isValidatorError': true
+			};
+
+			const res = ErrorUtils.guessStatusCode(err);
+			expect(res).toEqual(HttpStatus.UNPROCESSABLE_ENTITY);
+		});
+
+		it('should return 500 Server Error if the status code could not be determined', () => {
+			const err = new Error('msg');
+
+			const res = ErrorUtils.guessStatusCode(err);
+			expect(res).toEqual(HttpStatus.INTERNAL_SERVER_ERROR);
+		});
+	});
+
+	describe('isExpressError', () => {
+		it('should return true if an error is an ExpressError instance', () => {
+			const exprErr = new ExpressError('msg', HttpStatus.ACCEPTED);
+			const res = ErrorUtils.isExpressError(exprErr);
+			expect(res).toBe(true);
+		});
+
+		it('should return true if an error is an array of ExpressError instances', () => {
+			const exprErr = new ExpressError('msg', HttpStatus.ACCEPTED);
+			const res = ErrorUtils.isExpressError([exprErr]);
+			expect(res).toBe(true);
+		});
+
+		it('should return false if an error is a regular error', () => {
+			const err = new Error('msg');
+			const res = ErrorUtils.isExpressError(err);
+			expect(res).toBe(false);
+		});
+
+		it('should return false if the error is a regular object', () => {
+			const err = { name: 'test' };
+			const res = ErrorUtils.isExpressError(err);
+			expect(res).toBe(false);
+		});
+	});
+
+	describe('isErrorWithErrors', () => {
+		it('should return true if error object has a truthy errors property', () => {
+			const err = { errors: [] };
+			const res = ErrorUtils.isErrorWithErrors(err);
+			expect(res).toBe(true);
+		});
+
+		it('should return false if error object has a falsy errors property', () => {
+			const err = { errors: null };
+			const res = ErrorUtils.isErrorWithErrors(err);
+			expect(res).toBe(false);
+		});
+
+		it('should return false if error object does not have an errors property', () => {
+			const err = {};
+			const res = ErrorUtils.isErrorWithErrors(err);
+			expect(res).toBe(false);
+		});
+
+		it('should return false if error object is falsy', () => {
+			const err = null;
+			const res = ErrorUtils.isErrorWithErrors(err);
+			expect(res).toBe(false);
+		});
+	});
+});

--- a/tests/utils/express.error.spec.ts
+++ b/tests/utils/express.error.spec.ts
@@ -1,10 +1,24 @@
-import ExpressError from '../../src/utils/express.error';
+import * as HttpStatus from 'http-status-codes';
+import { ExpressError } from '../../src/utils/express.error';
 
 describe('ExpressError', () => {
-	it('should have correct properties', () => {
-		const error = new ExpressError('title', 'detail', 400);
-		expect(error.title).toEqual('title');
-		expect(error.detail).toEqual('detail');
-		expect(error.status).toEqual(400);
+	it('should create an instance with the text of the code as title', () => {
+		const err = new ExpressError('detail', HttpStatus.CONFLICT);
+		expect(err).toHaveProperty('title', '409 Conflict');
+	});
+
+	it('should create an instance with the text of the code as title', () => {
+		const err = new ExpressError('detail', HttpStatus.NOT_FOUND);
+		expect(err).toHaveProperty('title', '404 Not Found');
+	});
+
+	it('should create an instance with the text of the code as title', () => {
+		const err = new ExpressError('detail', HttpStatus.OK);
+		expect(err).toHaveProperty('title', '200 OK');
+	});
+
+	it('should create an instance with the text of the code as title', () => {
+		const err = new ExpressError('detail', HttpStatus.INTERNAL_SERVER_ERROR);
+		expect(err).toHaveProperty('title', '500 Server Error');
 	});
 });

--- a/tests/utils/router.utils.spec.ts
+++ b/tests/utils/router.utils.spec.ts
@@ -3,7 +3,7 @@ import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 import { MongoError } from 'mongodb';
 import RouterUtils from '../../src/utils/router.utils';
-import ExpressError from '../../src/utils/express.error';
+import { ExpressError } from '../../src/utils/express.error';
 
 describe('RouterUtils', () => {
 	let routerUtils: RouterUtils;
@@ -80,42 +80,10 @@ describe('RouterUtils', () => {
 	describe('errorHandler', () => {
 		it('should continue down middleware chain with error if response has been sent', () => {
 			const nextFn = sinon.stub();
+			const err = new ExpressError('err', 500);
 			RouterUtils.errorHandler('error', null, { 'headersSent': true } as any, nextFn);
 			expect(nextFn.calledWithExactly('error')).toBeTruthy();
 			expect(nextFn.calledOnce).toBeTruthy();
-			verifyAll();
-		});
-
-		it('should set status code as 500 Internal Server Error if generic error is caught', () => {
-			const err = new Error('msg');
-			_res.expects('status').withArgs(HttpStatus.INTERNAL_SERVER_ERROR).returns(res);
-			_res.expects('send').exactly(1);
-			RouterUtils.errorHandler(err, null, res, null);
-			verifyAll();
-		});
-
-		it('should set status code from error if express error is caught', () => {
-			const err = new ExpressError('title', 'detail', HttpStatus.NOT_FOUND);
-			_res.expects('status').withArgs(err.status).returns(res);
-			_res.expects('send').exactly(1);
-			RouterUtils.errorHandler(err, null, res, null);
-			verifyAll();
-		});
-
-		it('should set status code as 400 Bad Request if mongoose validation error is caught', () => {
-			const err = { 'name': 'ValidationError' };
-			_res.expects('status').withArgs(HttpStatus.UNPROCESSABLE_ENTITY).returns(res);
-			_res.expects('send').exactly(1);
-			RouterUtils.errorHandler(err, null, res, null);
-			verifyAll();
-		});
-
-		it('should MongoError with code 11000 is caught', () => {
-			const err = new MongoError('error');
-			err.code = 11001;
-			_res.expects('status').withArgs(HttpStatus.CONFLICT).returns(res);
-			_res.expects('send').exactly(1);
-			RouterUtils.errorHandler(err, null, res, null);
 			verifyAll();
 		});
 	});


### PR DESCRIPTION
- Central error handler class
- Simplified `ExpressError` by using the status code library to create the title
- Removing `default` export in `ExpressError` class and changing the imports