### PR TITLE
Include scores when fetching workout/movement by id

### DIFF
--- a/component_tests/movement.test.ts
+++ b/component_tests/movement.test.ts
@@ -166,7 +166,7 @@ describe('Movement component tests', () => {
 				expect(res1.body).toHaveProperty('measurement', movement.measurement);
 				expect(res1.body).toHaveProperty('name', movement.name);
 
-				const res2 = await request.post(`/movements/${movementId}/scores`, {
+				const res2 = await request.post(`/movements/${movementId}`, {
 					...reqOpts,
 					headers: {
 						'Content-Type': 'application/json',
@@ -186,7 +186,7 @@ describe('Movement component tests', () => {
 				expect(res2.body).toHaveProperty('movementId', movementId);
 				expect(res2.body).toHaveProperty('score', '200kg');
 
-				const res3 = await request.get(`/movements/${movementId}/scores`, {
+				const res3 = await request.get(`/movements/${movementId}`, {
 					...reqOpts,
 					headers: {
 						'Content-Type': 'application/json',
@@ -195,12 +195,12 @@ describe('Movement component tests', () => {
 				});
 
 				expect(res3.statusCode).toBe(HttpStatus.OK);
-				expect(res3.body.data).toHaveProperty('length', 1);
-				expect(res3.body.data[0]).toHaveProperty('id');
-				expect(res3.body.data[0]).toHaveProperty('createdAt');
-				expect(res3.body.data[0]).toHaveProperty('updatedAt');
-				expect(res3.body.data[0]).toHaveProperty('movementId');
-				expect(res3.body.data[0]).toHaveProperty('score');
+				expect(res3.body).toHaveProperty('scores');
+				expect(res3.body.scores[0]).toHaveProperty('id');
+				expect(res3.body.scores[0]).toHaveProperty('createdAt');
+				expect(res3.body.scores[0]).toHaveProperty('updatedAt');
+				expect(res3.body.scores[0]).toHaveProperty('movementId');
+				expect(res3.body.scores[0]).toHaveProperty('score');
 				done();
 			} catch (err) {
 				done(err);

--- a/component_tests/workout.test.ts
+++ b/component_tests/workout.test.ts
@@ -180,7 +180,7 @@ describe('Workout component tests', () => {
 				expect(res1.body).toHaveProperty('measurement', wod.measurement);
 				expect(res1.body).toHaveProperty('name', wod.name);
 
-				const res2 = await request.post(`/workouts/${workoutId}/scores`, {
+				const res2 = await request.post(`/workouts/${workoutId}`, {
 					...reqOpts,
 					headers: {
 						'Content-Type': 'application/json',
@@ -201,7 +201,7 @@ describe('Workout component tests', () => {
 				expect(res2.body).toHaveProperty('score', '4:20');
 				expect(res2.body).toHaveProperty('rx', true);
 
-				const res3 = await request.get(`/workouts/${workoutId}/scores`, {
+				const res3 = await request.get(`/workouts/${workoutId}`, {
 					...reqOpts,
 					headers: {
 						'Content-Type': 'application/json',
@@ -210,13 +210,13 @@ describe('Workout component tests', () => {
 				});
 
 				expect(res3.statusCode).toBe(HttpStatus.OK);
-				expect(res3.body.data).toHaveProperty('length', 1);
-				expect(res3.body.data[0]).toHaveProperty('id');
-				expect(res3.body.data[0]).toHaveProperty('createdAt');
-				expect(res3.body.data[0]).toHaveProperty('updatedAt');
-				expect(res3.body.data[0]).toHaveProperty('workoutId');
-				expect(res3.body.data[0]).toHaveProperty('score');
-				expect(res3.body.data[0]).toHaveProperty('rx');
+				expect(res3.body).toHaveProperty('scores');
+				expect(res3.body.scores[0]).toHaveProperty('id');
+				expect(res3.body.scores[0]).toHaveProperty('createdAt');
+				expect(res3.body.scores[0]).toHaveProperty('updatedAt');
+				expect(res3.body.scores[0]).toHaveProperty('workoutId');
+				expect(res3.body.scores[0]).toHaveProperty('score');
+				expect(res3.body.scores[0]).toHaveProperty('rx');
 				done();
 			} catch (err) {
 				done(err);

--- a/src/routes/workout.ts
+++ b/src/routes/workout.ts
@@ -1,6 +1,7 @@
 import * as Koa from 'koa';
 import * as Router from 'koa-router';
 import * as HttpStatus from 'http-status-codes';
+import * as _ from 'lodash';
 import { WorkoutService } from '../services/workout';
 
 export class WorkoutRouter extends Router {
@@ -15,9 +16,8 @@ export class WorkoutRouter extends Router {
 		this.prefix('/v1/workouts');
 		this.get('/', ctx => this.getWorkouts(ctx));
 		this.get('/:id', ctx => this.getWorkout(ctx));
-		this.get('/:id/scores', ctx => this.getScores(ctx));
 		this.post('/', ctx => this.createWorkout(ctx));
-		this.post('/:id/scores', ctx => this.addScore(ctx));
+		this.post('/:id', ctx => this.addScore(ctx));
 		app.use(this.routes());
 	}
 
@@ -33,11 +33,14 @@ export class WorkoutRouter extends Router {
 
 	async getWorkout(ctx: Koa.Context) {
 		const claims: Claims = ctx.state.claims;
-		const itemId: string = ctx.params.id;
-		const data = await this.workoutService.getWorkoutById(itemId, claims);
+		const workoutId: string = ctx.params.id;
+		const workout = await this.workoutService.getWorkoutById(workoutId, claims);
+		const scores = await this.workoutService.getScores(workoutId, claims);
+		const data = workout.toObject();
+		_.set(data, 'scores', scores.map(score => score.toObject()));
 
 		ctx.status = HttpStatus.OK;
-		ctx.body = data.toObject();
+		ctx.body = data;
 	}
 
 	async createWorkout(ctx: Koa.Context) {
@@ -47,17 +50,6 @@ export class WorkoutRouter extends Router {
 
 		ctx.status = HttpStatus.CREATED;
 		ctx.body = data.toObject();
-	}
-
-	async getScores(ctx: Koa.Context) {
-		const claims: Claims = ctx.state.claims;
-		const workoutId: string = ctx.params.id;
-		const data = await this.workoutService.getScores(workoutId, claims);
-
-		ctx.status = HttpStatus.OK;
-		ctx.body = {
-			data: data.map(item => item.toObject())
-		};
 	}
 
 	async addScore(ctx: Koa.Context) {


### PR DESCRIPTION
Makes more sense for a detailed object, saves another call to the API to only get scores.

```
{
    "id": "Qc25FXHeMybqgDHtMgsGszzOdWYlieH9",
    "userId": "_6IaaR8H6PXPHhAuoniey_vA1bG8W-2M",
    "name": "Thruster",
    "measurement": "weight",
    "createdAt": "2018-12-28T20:31:58.587Z",
    "updatedAt": "2018-12-28T20:31:58.587Z",
    "scores": [
        {
            "id": "K9TWbYYafnFe962I4JYjVQqmSI__F4xD",
            "movementId": "Qc25FXHeMybqgDHtMgsGszzOdWYlieH9",
            "userId": "_6IaaR8H6PXPHhAuoniey_vA1bG8W-2M",
            "score": 90,
            "measurement": "weight",
            "sets": 1,
            "reps": 1,
            "notes": "",
            "createdAt": "2011-07-04T00:00:00.000Z",
            "updatedAt": "2018-12-28T20:31:58.592Z"
        },
        {
            "id": "i37BIIYBcCsw89cCpZT-TcJPrG5ascVs",
            "movementId": "Qc25FXHeMybqgDHtMgsGszzOdWYlieH9",
            "userId": "_6IaaR8H6PXPHhAuoniey_vA1bG8W-2M",
            "score": 102.5,
            "measurement": "weight",
            "sets": 1,
            "reps": 1,
            "notes": "",
            "createdAt": "2017-11-22T00:00:00.000Z",
            "updatedAt": "2018-12-28T20:31:58.615Z"
        }
    ]
}
```