### PR TITLE
movement and movement score endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Back-end for the [wodbook-app](https://github.com/egilsster/wodbook-app).
 ## High-level TODO
 
 - Unit tests
-- Movement / movement scores
 - Uploading a sqlite file from myWOD and it parses it for your user
 - Optimize docker image for production
 - OpenAPI endpoint (probably wont need it, will be keeping an eye open for yaml parsers that enable me to write it in yaml and serve it as json)
@@ -136,6 +135,22 @@ Returns
 }
 ```
 
+#### `GET /v1/workouts/`
+
+```sh
+curl 'http://127.0.0.1:43210/v1/workouts/' \
+  -H "Content-Type: application/json" \
+  -H 'Authorization: Bearer '$TOKEN
+```
+
+Returns
+
+```json
+{
+  "data": []
+}
+```
+
 #### `POST /v1/workouts/`
 
 ```sh
@@ -187,5 +202,76 @@ Returns
   "created_at": "2020-05-28T11:32:08.962274+00:00",
   "updated_at": "2020-05-28T11:32:08.962274+00:00"
 }
+```
 
+#### `GET /v1/movements/`
+
+```sh
+curl 'http://127.0.0.1:43210/v1/movements/' \
+  -H "Content-Type: application/json" \
+  -H 'Authorization: Bearer '$TOKEN
+```
+
+Returns
+
+```json
+{
+  "data": []
+}
+```
+
+#### `POST /v1/movements/`
+
+```sh
+curl -X POST 'http://127.0.0.1:43210/v1/movements/' \
+  -H "Content-Type: application/json" \
+  -H 'Authorization: Bearer '$TOKEN \
+  --data '{
+    "name": "Shoulder Press",
+    "measurement": "reps"
+  }'
+```
+
+Returns
+
+```json
+{
+  "movement_id": "cfa7f858-9d3f-45b7-b292-9e495133d2fd",
+  "name": "Shoulder Press",
+  "measurement": "reps",
+  "global": false,
+  "created_at": "2020-05-24T14:49:56.698944+00:00",
+  "updated_at": "2020-05-24T14:49:56.698944+00:00"
+}
+
+```
+
+#### `POST /v1/movements/:id`
+
+```sh
+curl -X POST 'http://127.0.0.1:43210/v1/movements/cfa7f858-9d3f-45b7-b292-9e495133d2fd' \
+  -H "Content-Type: application/json" \
+  -H 'Authorization: Bearer '$TOKEN \
+  --data '{
+    "score": "70",
+    "reps": 2,
+    "sets": 3,
+    "notes": "After a wod"
+  }'
+```
+
+Returns
+
+```json
+{
+  "movement_score_id": "89ee566a-9eed-48ac-9313-4a3dbc7e535c",
+  "movement_id": "cfa7f858-9d3f-45b7-b292-9e495133d2fd",
+  "score": "70",
+  "sets": 3,
+  "reps": 2,
+  "distance": "",
+  "notes": "After a wod",
+  "created_at": "2020-05-24T17:26:33.702924+00:00",
+  "updated_at": "2020-05-24T17:26:33.702924+00:00"
+}
 ```

--- a/component_tests/types/movement.d.ts
+++ b/component_tests/types/movement.d.ts
@@ -1,0 +1,24 @@
+type MovementData = {
+  movement_id: string;
+  user_id: string;
+  name: string;
+  measurement: string;
+  global: boolean;
+  scores: any[]; // TODO(egilsster): add scores for movements
+  created_at: string;
+  update_at: string;
+};
+
+type ManyMovementsData = {
+  data: MovementData[];
+};
+
+declare type MovementResponse = {
+  statusCode: number;
+  body: MovementData;
+};
+
+declare type ManyMovementsResponse = {
+  statusCode: number;
+  body: ManyMovementsData;
+};

--- a/component_tests/workout.test.ts
+++ b/component_tests/workout.test.ts
@@ -194,7 +194,7 @@ describe("/v1/workouts", () => {
       }
     });
 
-    it("should get 422 Unprocessable entity if using an invalid measurement", async (done) => {
+    it("should get 422 Unprocessable Entity if using an invalid measurement", async (done) => {
       try {
         const res: WorkoutResponse = await request.post("/workouts/", {
           ...reqOpts,
@@ -284,7 +284,8 @@ describe("/v1/workouts", () => {
 
         expect(res3.statusCode).toBe(HttpStatus.OK);
         expect(res3.body).toHaveProperty("scores");
-        expect(res3.body.scores[0]).toHaveProperty("workout_id");
+        expect(res3.body.scores[0]).toHaveProperty("workout_score_id");
+        expect(res3.body.scores[0]).toHaveProperty("workout_id", workoutId);
         expect(res3.body.scores[0]).toHaveProperty("created_at");
         expect(res3.body.scores[0]).toHaveProperty("updated_at");
         expect(res3.body.scores[0]).toHaveProperty("score");
@@ -321,12 +322,12 @@ describe("/v1/workouts", () => {
         expect(res1.statusCode).toBe(HttpStatus.CREATED);
         expect(res1.body).toHaveProperty("workout_id");
         const workoutId = res1.body.workout_id;
+        expect(res1.body).toHaveProperty("name", wod.name);
+        expect(res1.body).toHaveProperty("description", wod.description);
+        expect(res1.body).toHaveProperty("measurement", wod.measurement);
+        expect(res1.body).toHaveProperty("global", false);
         expect(res1.body).toHaveProperty("created_at");
         expect(res1.body).toHaveProperty("updated_at");
-        expect(res1.body).toHaveProperty("description", wod.description);
-        expect(res1.body).toHaveProperty("global", false);
-        expect(res1.body).toHaveProperty("measurement", wod.measurement);
-        expect(res1.body).toHaveProperty("name", wod.name);
 
         const res2: WorkoutResponse = await request.get(
           `/workouts/${workoutId}`,
@@ -341,12 +342,12 @@ describe("/v1/workouts", () => {
 
         expect(res2.statusCode).toBe(HttpStatus.OK);
         expect(res2.body).toHaveProperty("workout_id");
+        expect(res2.body).toHaveProperty("name", wod.name);
+        expect(res2.body).toHaveProperty("description", wod.description);
+        expect(res2.body).toHaveProperty("measurement", wod.measurement);
+        expect(res2.body).toHaveProperty("global", false);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("description", wod.description);
-        expect(res2.body).toHaveProperty("global", false);
-        expect(res2.body).toHaveProperty("measurement", wod.measurement);
-        expect(res2.body).toHaveProperty("name", wod.name);
 
         const res3: WorkoutResponse = await request.get(
           `/workouts/${workoutId}`,
@@ -390,12 +391,12 @@ describe("/v1/workouts", () => {
         expect(res1.statusCode).toBe(HttpStatus.CREATED);
         expect(res1.body).toHaveProperty("workout_id");
         const workoutId = res1.body.workout_id;
+        expect(res1.body).toHaveProperty("name", wod.name);
+        expect(res1.body).toHaveProperty("description", wod.description);
+        expect(res1.body).toHaveProperty("measurement", wod.measurement);
+        expect(res1.body).toHaveProperty("global", true);
         expect(res1.body).toHaveProperty("created_at");
         expect(res1.body).toHaveProperty("updated_at");
-        expect(res1.body).toHaveProperty("description", wod.description);
-        expect(res1.body).toHaveProperty("global", true);
-        expect(res1.body).toHaveProperty("measurement", wod.measurement);
-        expect(res1.body).toHaveProperty("name", wod.name);
 
         const res2: WorkoutResponse = await request.get(
           `/workouts/${workoutId}`,
@@ -410,12 +411,12 @@ describe("/v1/workouts", () => {
 
         expect(res2.statusCode).toBe(HttpStatus.OK);
         expect(res2.body).toHaveProperty("workout_id");
+        expect(res2.body).toHaveProperty("name", wod.name);
+        expect(res2.body).toHaveProperty("description", wod.description);
+        expect(res2.body).toHaveProperty("measurement", wod.measurement);
+        expect(res2.body).toHaveProperty("global", true);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("description", wod.description);
-        expect(res2.body).toHaveProperty("global", true);
-        expect(res2.body).toHaveProperty("measurement", wod.measurement);
-        expect(res2.body).toHaveProperty("name", wod.name);
 
         const res3: WorkoutResponse = await request.get(
           `/workouts/${workoutId}`,
@@ -430,12 +431,12 @@ describe("/v1/workouts", () => {
 
         expect(res3.statusCode).toBe(HttpStatus.OK);
         expect(res2.body).toHaveProperty("workout_id");
+        expect(res2.body).toHaveProperty("name", wod.name);
+        expect(res2.body).toHaveProperty("description", wod.description);
+        expect(res2.body).toHaveProperty("measurement", wod.measurement);
+        expect(res2.body).toHaveProperty("global", true);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("description", wod.description);
-        expect(res2.body).toHaveProperty("global", true);
-        expect(res2.body).toHaveProperty("measurement", wod.measurement);
-        expect(res2.body).toHaveProperty("name", wod.name);
 
         done();
       } catch (err) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             // Setup endpoints (strictest matcher first)
             .service(web::scope("/v1/users").configure(routes::users::init_routes))
+            .service(web::scope("/v1/movements").configure(routes::movements::init_routes))
             .service(web::scope("/v1/workouts").configure(routes::workouts::init_routes))
             .service(web::scope("/").configure(routes::index::init_routes))
     })

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
 pub mod response;
 pub mod user;
 pub mod workout;
+pub mod movement;

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+use std::vec::Vec;
+
+// https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006
+fn default_as_false() -> bool {
+    false
+}
+
+fn default_as_empty_string() -> String {
+    "".to_string()
+}
+
+fn default_as_one() -> u32 {
+    1
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MovementModel {
+    pub movement_id: String,
+    pub name: String,
+    pub measurement: String,
+    pub global: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MovementResponse {
+    pub movement_id: String,
+    pub name: String,
+    pub measurement: String,
+    pub scores: Vec<MovementScoreResponse>,
+    pub global: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl MovementResponse {
+    pub fn from_model(model: MovementModel, scores: Vec<MovementScoreResponse>) -> Self {
+        MovementResponse {
+            movement_id: model.movement_id,
+            name: model.name,
+            measurement: model.measurement,
+            scores: scores,
+            global: model.global,
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ManyMovementsResponse {
+    pub data: Vec<MovementModel>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ManyMovementScoresResponse {
+    pub data: Vec<MovementScoreResponse>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateMovement {
+    pub name: String,
+    pub measurement: String,
+    #[serde(default = "default_as_false")]
+    pub global: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateMovementScore {
+    pub score: String,
+    #[serde(default = "default_as_one")]
+    pub sets: u32,
+    #[serde(default = "default_as_one")]
+    pub reps: u32,
+    #[serde(default = "default_as_empty_string")]
+    pub distance: String,
+    #[serde(default = "default_as_empty_string")]
+    pub notes: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MovementScoreResponse {
+    pub movement_score_id: String,
+    pub movement_id: String,
+    pub score: String,
+    pub sets: u32,
+    pub reps: u32,
+    pub distance: String,
+    pub notes: String,
+    pub created_at: String,
+    pub updated_at: String,
+}

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub mod user_repository;
 pub mod workout_repository;
+pub mod movement_repository;

--- a/src/repositories/movement_repository/mod.rs
+++ b/src/repositories/movement_repository/mod.rs
@@ -1,0 +1,5 @@
+mod movement_repository;
+mod movement_score_repository;
+
+pub use movement_repository::MovementRepository;
+pub use movement_score_repository::MovementScoreRepository;

--- a/src/repositories/movement_repository/movement_repository.rs
+++ b/src/repositories/movement_repository/movement_repository.rs
@@ -1,0 +1,168 @@
+use crate::errors::AppError;
+use crate::models::movement::{CreateMovement, MovementModel};
+use crate::utils::Config;
+
+use bson::{doc, from_bson, Bson};
+use chrono::Utc;
+use futures::stream::StreamExt;
+use mongodb::options::FindOptions;
+use mongodb::{Client, Collection};
+use std::vec::Vec;
+
+static WORKOUT_COLLECTION_NAME: &'static str = "movements";
+
+// TODO(egilsster): Can this be done with enum (and match?)?
+static VALID_MEASUREMENTS: [&str; 4] = ["weight", "distance", "reps", "height"];
+
+pub struct MovementRepository {
+    pub mongo_client: Client,
+}
+
+impl MovementRepository {
+    fn get_movement_collection(&self) -> Collection {
+        let config = Config::from_env().unwrap();
+        let database_name = config.mongo.db_name;
+        let db = self.mongo_client.database(database_name.as_str());
+        db.collection(WORKOUT_COLLECTION_NAME)
+    }
+
+    pub async fn find_movement_by_name(
+        &self,
+        user_id: String,
+        name: String,
+    ) -> Result<Option<MovementModel>, AppError> {
+        let filter = doc! { "$or": [ { "user_id": user_id, "name": name }, { "global": true } ] };
+        let cursor = self
+            .get_movement_collection()
+            .find_one(filter, None)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()))?;
+
+        match cursor {
+            Some(doc) => match from_bson(Bson::Document(doc)) {
+                Ok(model) => Ok(model),
+                Err(e) => Err(AppError::DbError(e.to_string())),
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub async fn find_movement_by_id(
+        &self,
+        user_id: String,
+        movement_id: String,
+    ) -> Result<Option<MovementModel>, AppError> {
+        let filter = doc! { "$or": [ { "movement_id": movement_id, "user_id": user_id }, { "global": true } ] };
+        let cursor = self
+            .get_movement_collection()
+            .find_one(filter, None)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()))?;
+
+        match cursor {
+            Some(doc) => match from_bson(Bson::Document(doc)) {
+                Ok(model) => Ok(model),
+                Err(e) => Err(AppError::DbError(e.to_string())),
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub async fn get_movements(&self, user_id: String) -> Result<Vec<MovementModel>, AppError> {
+        let filter = doc! { "$or": [ { "user_id": user_id }, { "global": true } ] };
+        let find_options = FindOptions::builder().sort(doc! { "name": 1 }).build();
+        let mut cursor = self
+            .get_movement_collection()
+            .find(filter, find_options)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()))?;
+
+        let mut vec: Vec<MovementModel> = Vec::new();
+
+        while let Some(result) = cursor.next().await {
+            match result {
+                Ok(document) => {
+                    let movement = from_bson::<MovementModel>(Bson::Document(document));
+                    match movement {
+                        Ok(result) => vec.push(result),
+                        Err(e) => println!("Error parsing movement: {:?}", e),
+                    }
+                }
+                Err(e) => println!("Error reading movement: {:?}", e),
+            }
+        }
+
+        Ok(vec)
+    }
+
+    pub async fn get_movement_by_id(
+        &self,
+        user_id: String,
+        movement_id: String,
+    ) -> Result<MovementModel, AppError> {
+        let movement = self
+            .find_movement_by_id(user_id.to_owned(), movement_id)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()))?;
+
+        match movement {
+            Some(_) => Ok(movement.unwrap()),
+            None => Err(AppError::NotFound("Entity not found".to_string())),
+        }
+    }
+
+    pub async fn create_movement(
+        &self,
+        user_id: String,
+        movement: CreateMovement,
+    ) -> Result<MovementModel, AppError> {
+        let measurement = movement.measurement.to_owned();
+        if !VALID_MEASUREMENTS.contains(&measurement.as_str()) {
+            return Err(AppError::UnprocessableEntity(format!(
+                "Invalid measurement, should be one of: {}",
+                VALID_MEASUREMENTS.join(", ")
+            )));
+        }
+
+        let movement_name = movement.name.to_string();
+        let _exist = self
+            .find_movement_by_name(user_id.to_owned(), movement_name.to_owned())
+            .await
+            .unwrap();
+        match _exist {
+            Some(_) => Err(AppError::Conflict(
+                "Movement with this name already exists".to_string(),
+            )),
+            None => {
+                let coll = self.get_movement_collection();
+                let id = uuid::Uuid::new_v4().to_string();
+                let now = Utc::now().to_rfc3339();
+                let movement_doc = doc! {
+                    "movement_id": id,
+                    "user_id": user_id.to_owned(),
+                    "name": movement.name,
+                    "measurement": movement.measurement,
+                    "global": movement.global,
+                    "created_at": now.to_owned(),
+                    "updated_at": now.to_owned(),
+                };
+
+                let _ = coll
+                    .insert_one(movement_doc, None)
+                    .await
+                    .map_err(|err| AppError::DbError(err.to_string()));
+
+                match self
+                    .find_movement_by_name(user_id.to_owned(), movement_name.to_owned())
+                    .await
+                    .unwrap()
+                {
+                    Some(new_movement) => Ok(new_movement),
+                    None => Err(AppError::DbError(
+                        "New movement not found after inserting".to_string(),
+                    )),
+                }
+            }
+        }
+    }
+}

--- a/src/repositories/movement_repository/movement_score_repository.rs
+++ b/src/repositories/movement_repository/movement_score_repository.rs
@@ -1,0 +1,165 @@
+use crate::errors::AppError;
+use crate::models::movement::{CreateMovementScore, MovementScoreResponse};
+use crate::utils::Config;
+
+use bson::{doc, from_bson, Bson};
+use chrono::Utc;
+use futures::stream::StreamExt;
+use mongodb::options::FindOptions;
+use mongodb::{Client, Collection};
+use std::vec::Vec;
+
+static SCORE_COLLECTION_NAME: &'static str = "movementscores";
+
+pub struct MovementScoreRepository {
+    pub mongo_client: Client,
+}
+
+impl MovementScoreRepository {
+    fn get_score_collection(&self) -> Collection {
+        let config = Config::from_env().unwrap();
+        let database_name = config.mongo.db_name;
+        let db = self.mongo_client.database(database_name.as_str());
+        db.collection(SCORE_COLLECTION_NAME)
+    }
+
+    pub async fn create_movement_score(
+        &self,
+        user_id: String,
+        movement_id: String,
+        movement_score: CreateMovementScore,
+    ) -> Result<MovementScoreResponse, AppError> {
+        let coll = self.get_score_collection();
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let movement_score_doc = doc! {
+            "movement_score_id": id.to_owned(),
+            "user_id": user_id.to_owned(),
+            "movement_id": movement_id.to_owned(),
+            "score": movement_score.score,
+            "sets": movement_score.sets,
+            "reps": movement_score.reps,
+            "distance": movement_score.distance,
+            "notes": movement_score.notes,
+            "created_at": now.to_owned(),
+            "updated_at": now.to_owned(),
+        };
+
+        let _ = coll
+            .insert_one(movement_score_doc, None)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()));
+
+        self.get_movement_score_by_id(user_id.to_owned(), movement_id.to_owned(), id.to_owned())
+            .await
+            .map_err(|_| AppError::DbError("Score not found after inserting".to_string()))
+    }
+
+    pub async fn get_movement_scores(
+        &self,
+        user_id: String,
+        movement_id: String,
+    ) -> Result<Vec<MovementScoreResponse>, AppError> {
+        let filter = doc! { "user_id": user_id, "movement_id": movement_id };
+        let find_options = FindOptions::builder()
+            .sort(doc! { "created_at": 1 })
+            .build();
+        let mut cursor = self
+            .get_score_collection()
+            .find(filter, find_options)
+            .await
+            .unwrap();
+
+        let mut vec: Vec<MovementScoreResponse> = Vec::new();
+
+        while let Some(result) = cursor.next().await {
+            match result {
+                Ok(document) => {
+                    let movement_score =
+                        from_bson::<MovementScoreResponse>(Bson::Document(document));
+                    match movement_score {
+                        Ok(result) => vec.push(result),
+                        Err(e) => println!("Error parsing movement: {:?}", e),
+                    }
+                }
+                Err(e) => println!("Error reading movement: {:?}", e),
+            }
+        }
+
+        Ok(vec)
+    }
+
+    pub async fn get_movement_score_by_id(
+        &self,
+        user_id: String,
+        movement_id: String,
+        movement_score_id: String,
+    ) -> Result<MovementScoreResponse, AppError> {
+        let filter = doc! { "user_id": user_id, "movement_id":  movement_id, "movement_score_id": movement_score_id };
+        let cursor = self
+            .get_score_collection()
+            .find_one(filter, None)
+            .await
+            .map_err(|err| AppError::DbError(err.to_string()))?;
+
+        match cursor {
+            Some(doc) => match from_bson(Bson::Document(doc)) {
+                Ok(model) => Ok(model),
+                Err(err) => Err(AppError::DbError(err.to_string())),
+            },
+            None => Err(AppError::NotFound("Entity not found".to_string())),
+        }
+    }
+
+    // pub async fn update_movement_score_by_id(
+    //     &self,
+    //     user_id: String,
+    // ) -> Result<Option<MovementScoreResponse>, ErrorResponse> {
+    //     let _exist = self
+    //         .find_movement_by_id(user_id.to_owned(), movement_id.to_owned())
+    //         .await
+    //         .unwrap();
+
+    //     match _exist {
+    //         Some(_) => Err(ErrorResponse {
+    //             message: "Movement not found.".to_string(),
+    //             status: StatusCode::NOT_FOUND.as_u16(),
+    //         }),
+    //         None => {
+    //             let coll = self.get_collection();
+    //             let id = uuid::Uuid::new_v4().to_string();
+    //             let now = Utc::now().to_rfc2822();
+    //             let movement_doc = doc! {
+    //                 "movement_id": id,
+    //                 "user_id": user_id.to_owned(),
+    //                 "name": movement.name,
+    //                 "description": movement.description,
+    //                 "measurement": movement.measurement,
+    //                 "global": movement.global,
+    //                 "created_at": now.to_owned(),
+    //                 "updated_at": now.to_owned(),
+    //             };
+
+    //             match coll.insert_one(movement_doc, None).await {
+    //                 Ok(_) => {
+    //                     match self
+    //                         .find_movement_by_name(user_id.to_owned(), movement_name.to_owned())
+    //                         .await
+    //                         .unwrap()
+    //                     {
+    //                         Some(new_movement) => Ok(new_movement),
+    //                         None => Err(ErrorResponse {
+    //                             message: "New movement not found after inserting".to_string(),
+    //                             status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+    //                         }),
+    //                     }
+    //                 }
+    //                 Err(_) => Err(ErrorResponse {
+    //                     message: "Something went wrong when inserting a movement.".to_string(),
+    //                     status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+    //                 }),
+    //             }
+    //         }
+    //     }
+    // }
+}

--- a/src/repositories/workout_repository/workout_repository.rs
+++ b/src/repositories/workout_repository/workout_repository.rs
@@ -67,7 +67,7 @@ impl WorkoutRepository {
             .get_workout_collection()
             .find_one(filter, None)
             .await
-            .unwrap();
+            .map_err(|err| AppError::DbError(err.to_string()))?;
 
         match cursor {
             Some(doc) => match from_bson(Bson::Document(doc)) {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod index;
 pub mod users;
 pub mod workouts;
+pub mod movements;

--- a/src/routes/movements.rs
+++ b/src/routes/movements.rs
@@ -1,0 +1,112 @@
+use crate::errors::AppError;
+use crate::models::movement::{
+    CreateMovement, CreateMovementScore, ManyMovementsResponse, MovementResponse,
+};
+use crate::models::user::Claims;
+use crate::repositories::movement_repository::{MovementRepository, MovementScoreRepository};
+use crate::utils::AppState;
+use actix_web::{get, post, web, HttpResponse, Responder};
+use slog::{info, o};
+
+#[get("/")]
+async fn get_movements(
+    state: web::Data<AppState>,
+    claims: Claims,
+) -> Result<impl Responder, AppError> {
+    let logger = state.logger.new(o!("handler" => "GET /movements"));
+    info!(logger, "Getting all movements");
+    let movement_repo = MovementRepository {
+        mongo_client: state.mongo_client.clone(),
+    };
+
+    let user_id = claims.user_id.to_owned();
+    let result = movement_repo.get_movements(user_id).await;
+
+    result.map(|movements| HttpResponse::Ok().json(ManyMovementsResponse { data: movements }))
+}
+
+#[post("/")]
+async fn create_movement(
+    state: web::Data<AppState>,
+    claims: Claims,
+    movement: web::Json<CreateMovement>,
+) -> Result<impl Responder, AppError> {
+    let logger = state.logger.new(o!("handler" => "POST /movements"));
+    info!(logger, "Creating a new movement");
+    let movement_repo = MovementRepository {
+        mongo_client: state.mongo_client.clone(),
+    };
+
+    let user_id = claims.user_id.to_owned();
+    let result = movement_repo
+        .create_movement(user_id, movement.into_inner())
+        .await;
+
+    result.map(|movement| HttpResponse::Created().json(movement))
+}
+
+#[get("/{id}")]
+async fn get_movement_by_id(
+    state: web::Data<AppState>,
+    info: web::Path<String>,
+    claims: Claims,
+) -> Result<impl Responder, AppError> {
+    let movement_id = info.to_owned();
+    let logger = state
+        .logger
+        .new(o!("handler" => format!("GET /movements/{}", movement_id.to_owned())));
+    info!(logger, "Getting movement by id");
+
+    let movement_repo = MovementRepository {
+        mongo_client: state.mongo_client.clone(),
+    };
+    let score_repo = MovementScoreRepository {
+        mongo_client: state.mongo_client.clone(),
+    };
+
+    let user_id = claims.user_id.to_owned();
+    let movement_result = movement_repo
+        .get_movement_by_id(user_id.to_owned(), movement_id.to_owned())
+        .await;
+    let scores_result = score_repo
+        .get_movement_scores(user_id.to_owned(), movement_id.to_owned())
+        .await;
+
+    movement_result.map(|movement| {
+        scores_result
+            .map(|scores| HttpResponse::Ok().json(MovementResponse::from_model(movement, scores)))
+    })
+}
+
+#[post("/{id}")]
+async fn create_movement_score(
+    state: web::Data<AppState>,
+    info: web::Path<String>,
+    claims: Claims,
+    movement_score: web::Json<CreateMovementScore>,
+) -> Result<impl Responder, AppError> {
+    let movement_id = info.to_owned();
+    let logger = state
+        .logger
+        .new(o!("handler" => format!("POST /movements/{}", movement_id.to_owned())));
+    info!(logger, "Creating movement score");
+
+    let score_repo = MovementScoreRepository {
+        mongo_client: state.mongo_client.clone(),
+    };
+
+    let movement_id = info.to_owned();
+    let user_id = claims.user_id.to_owned();
+    let scores_result = score_repo
+        .create_movement_score(user_id, movement_id, movement_score.into_inner())
+        .await;
+
+    scores_result.map(|score| HttpResponse::Created().json(score))
+}
+
+pub fn init_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_movements);
+    cfg.service(create_movement);
+    cfg.service(get_movement_by_id);
+    cfg.service(create_movement_score);
+}


### PR DESCRIPTION
```
λ curl 'http://127.0.0.1:43210/v1/movements/' \                                            
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer '$TOKEN
{
  "data": []
}
λ curl -X POST 'http://127.0.0.1:43210/v1/movements/' \
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer '$TOKEN \
  --data '{
    "name": "Shoulder Press",
    "measurement": "reps"
  }'
{
  "movement_id": "044cc66a-abe7-4c9f-9280-f4a7995a0e8c",
  "name": "Shoulder Press",
  "measurement": "reps",
  "global": false,
  "created_at": "2020-05-24T18:03:55.385613+00:00",
  "updated_at": "2020-05-24T18:03:55.385613+00:00"
}
λ curl -X POST 'http://127.0.0.1:43210/v1/movements/044cc66a-abe7-4c9f-9280-f4a7995a0e8c' \
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer '$TOKEN \
  --data '{
    "score": "70",
    "reps": 2,
    "sets": 3,
    "notes": "After a wod"
  }'
{
  "movement_score_id": "8c2dfeed-ccfd-4db8-b1e1-6683d398711b",
  "movement_id": "044cc66a-abe7-4c9f-9280-f4a7995a0e8c",
  "score": "70",
  "sets": 3,
  "reps": 2,
  "distance": "",
  "notes": "After a wod",
  "created_at": "2020-05-24T18:05:24.620722+00:00",
  "updated_at": "2020-05-24T18:05:24.620722+00:00"
}
λ curl 'http://127.0.0.1:43210/v1/movements/044cc66a-abe7-4c9f-9280-f4a7995a0e8c' \        
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer '$TOKEN | jq .
{
  "movement_id": "044cc66a-abe7-4c9f-9280-f4a7995a0e8c",
  "name": "Shoulder Press",
  "measurement": "reps",
  "scores": [
    {
      "movement_score_id": "8c2dfeed-ccfd-4db8-b1e1-6683d398711b",
      "movement_id": "044cc66a-abe7-4c9f-9280-f4a7995a0e8c",
      "score": "70",
      "sets": 3,
      "reps": 2,
      "distance": "",
      "notes": "After a wod",
      "created_at": "2020-05-24T18:05:24.620722+00:00",
      "updated_at": "2020-05-24T18:05:24.620722+00:00"
    }
  ],
  "global": false,
  "created_at": "2020-05-24T18:03:55.385613+00:00",
  "updated_at": "2020-05-24T18:03:55.385613+00:00"
}
```