### PR TITLE
feat: patch endpoint to update user

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -14,7 +14,7 @@ tags:
   - name: workouts
     description: Workouts are combinations of movements done with the purpose of measuring your performance.
   - name: movements
-    description: Movements are execises for users to track their progress.
+    description: Movements are exercises for users to track their progress.
 security:
   - bearerAuth: []
 servers:
@@ -79,6 +79,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/user"
+        400:
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    patch:
+      summary: Updates information about the logged in user.
+      operationId: updateUser
+      tags:
+        - users
+      responses:
+        200:
+          description: OK. User has been updated and returns user information.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/user"
+        400:
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
   /workouts/:
     get:
       summary: List all workouts.

--- a/component_tests/user.test.ts
+++ b/component_tests/user.test.ts
@@ -20,6 +20,9 @@ describe("/users", () => {
     mongoClient = await MongoClient.connect(MONGO_URI, {
       useUnifiedTopology: true,
     });
+  });
+
+  beforeEach(async () => {
     const db = mongoClient.db();
     const coll = db.collection("users");
     await coll.deleteMany({});
@@ -162,6 +165,222 @@ describe("/users", () => {
           expect(res2.body).toHaveProperty("weight", 85000);
           expect(res2.body).toHaveProperty("date_of_birth");
           expect(res2.body).toHaveProperty("password");
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+
+    describe("PATCH", () => {
+      it("should update user information", async (done) => {
+        try {
+          const user = {
+            first_name: "Hansel",
+            last_name: "Dude",
+            box_name: "Zoolander",
+            email: "hansel@zoolander.com",
+            height: 183,
+            weight: 82000,
+            date_of_birth: "1985-05-01",
+            password: "so-hot-right-now",
+          };
+
+          const res1 = await request.post("users/register", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: user,
+          });
+
+          expect(res1.statusCode).toBe(HttpStatus.CREATED);
+          expect(res1.body).toHaveProperty("user_id");
+          expect(res1.body).toHaveProperty("first_name", user.first_name);
+          expect(res1.body).toHaveProperty("last_name", user.last_name);
+          expect(res1.body).toHaveProperty("box_name", user.box_name);
+          expect(res1.body).toHaveProperty("email", user.email);
+          expect(res1.body).toHaveProperty("height", user.height);
+          expect(res1.body).toHaveProperty("weight", user.weight);
+          expect(res1.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res1.body).not.toHaveProperty("password");
+
+          const res2 = await request.post("users/login", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: {
+              email: user.email,
+              password: user.password,
+            },
+          });
+
+          expect(res2.statusCode).toBe(HttpStatus.OK);
+          expect(res2.body).toHaveProperty("token");
+          const { token } = res2.body;
+
+          const res3 = await request.get("users/me", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          expect(res3.statusCode).toBe(HttpStatus.OK);
+          expect(res3.body).toHaveProperty("user_id");
+          expect(res3.body).toHaveProperty("first_name", user.first_name);
+          expect(res3.body).toHaveProperty("last_name", user.last_name);
+          expect(res3.body).toHaveProperty("box_name", user.box_name);
+          expect(res3.body).toHaveProperty("email", user.email);
+          expect(res3.body).toHaveProperty("height", user.height);
+          expect(res3.body).toHaveProperty("weight", user.weight);
+          expect(res3.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res3.body).toHaveProperty("password");
+
+          const res4 = await request.patch("users/me", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: {
+              first_name: "new first_name",
+              last_name: "new last_name",
+              box_name: "new box_name",
+            },
+          });
+
+          expect(res4.statusCode).toBe(HttpStatus.OK);
+          // Verify new data
+          expect(res4.body).toHaveProperty("first_name", "new first_name");
+          expect(res4.body).toHaveProperty("last_name", "new last_name");
+          expect(res4.body).toHaveProperty("box_name", "new box_name");
+          // Verify that unchanged data remains there
+          expect(res4.body).toHaveProperty("email", user.email);
+          expect(res4.body).toHaveProperty("height", user.height);
+          expect(res4.body).toHaveProperty("weight", user.weight);
+          expect(res4.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res4.body).toHaveProperty("password");
+
+          // Verify that the GET requests returns the same data
+          const res5 = await request.get("users/me", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          expect(res5.statusCode).toBe(HttpStatus.OK);
+          expect(res5.body).toHaveProperty("user_id");
+          expect(res5.body).toHaveProperty("first_name", "new first_name");
+          expect(res5.body).toHaveProperty("last_name", "new last_name");
+          expect(res5.body).toHaveProperty("box_name", "new box_name");
+          expect(res5.body).toHaveProperty("email", user.email);
+          expect(res5.body).toHaveProperty("height", user.height);
+          expect(res5.body).toHaveProperty("weight", user.weight);
+          expect(res5.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res5.body).toHaveProperty("password");
+
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      it("should change password", async (done) => {
+        try {
+          const user = {
+            first_name: "Hansel",
+            last_name: "Dude",
+            box_name: "Zoolander",
+            email: "hansel@zoolander.com",
+            height: 183,
+            weight: 82000,
+            date_of_birth: "1985-05-01",
+            password: "so-hot-right-now",
+          };
+
+          const res1 = await request.post("users/register", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: user,
+          });
+
+          expect(res1.statusCode).toBe(HttpStatus.CREATED);
+          expect(res1.body).toHaveProperty("user_id");
+          expect(res1.body).toHaveProperty("first_name", user.first_name);
+          expect(res1.body).toHaveProperty("last_name", user.last_name);
+          expect(res1.body).toHaveProperty("box_name", user.box_name);
+          expect(res1.body).toHaveProperty("email", user.email);
+          expect(res1.body).toHaveProperty("height", user.height);
+          expect(res1.body).toHaveProperty("weight", user.weight);
+          expect(res1.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res1.body).not.toHaveProperty("password");
+
+          const res2 = await request.post("users/login", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: {
+              email: user.email,
+              password: user.password,
+            },
+          });
+
+          expect(res2.statusCode).toBe(HttpStatus.OK);
+          expect(res2.body).toHaveProperty("token");
+          const { token } = res2.body;
+
+          const new_pass = "my-new-password";
+
+          const res3 = await request.patch("users/me", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: {
+              password: new_pass,
+            },
+          });
+
+          expect(res3.statusCode).toBe(HttpStatus.OK);
+
+          // Verify that login works with the new password
+          const res4 = await request.post("users/login", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: {
+              email: user.email,
+              password: new_pass,
+            },
+          });
+
+          expect(res4.statusCode).toBe(HttpStatus.OK);
+          expect(res4.body).toHaveProperty("token");
+
+          // Verify that login does NOT work with the old password
+          const res5 = await request.post("users/login", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: {
+              email: user.email,
+              password: user.password,
+            },
+          });
+
+          expect(res5.statusCode).toBe(HttpStatus.BAD_REQUEST);
+
           done();
         } catch (err) {
           done(err);

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -38,7 +38,7 @@ pub struct Claims {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Register {
+pub struct CreateUser {
     pub email: String,
     pub password: String,
     pub first_name: String,
@@ -47,4 +47,17 @@ pub struct Register {
     pub height: i32,
     pub weight: i32,
     pub box_name: String,
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct UpdateUser {
+    pub password: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub date_of_birth: Option<String>,
+    pub height: Option<i32>,
+    pub weight: Option<i32>,
+    pub box_name: Option<String>,
+    pub avatar_url: Option<String>,
 }

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,9 +1,9 @@
 use crate::errors::AppError;
 use crate::models::user::Claims;
-use crate::models::user::{Login, Register};
+use crate::models::user::{CreateUser, Login, UpdateUser};
 use crate::repositories::user_repository::UserRepository;
 use crate::utils::AppState;
-use actix_web::{get, post, web, HttpResponse, Responder};
+use actix_web::{get, post, patch, web, HttpResponse, Responder};
 use slog::{info, o};
 
 #[post("/login")]
@@ -25,7 +25,7 @@ async fn login(
 #[post("/register")]
 async fn register(
     state: web::Data<AppState>,
-    user: web::Json<Register>,
+    user: web::Json<CreateUser>,
 ) -> Result<impl Responder, AppError> {
     let logger = state.logger.new(o!("handler" => "POST /register"));
     info!(logger, "Registering new user");
@@ -54,19 +54,21 @@ async fn get_user_information(
     result.map(|user| HttpResponse::Ok().json(user))
 }
 
-#[post("/me")]
+#[patch("/me")]
 async fn update_user_information(
     state: web::Data<AppState>,
     claims: Claims,
+    user: web::Json<UpdateUser>,
 ) -> Result<impl Responder, AppError> {
-    // TODO(egilsster): Implement updating user
-    let logger = state.logger.new(o!("handler" => "POST /me"));
+    let logger = state.logger.new(o!("handler" => "PATCH /me"));
     info!(logger, "Updating information about logged in user");
     let user_repo = UserRepository {
         mongo_client: state.mongo_client.clone(),
     };
 
-    let result = user_repo.user_information(claims.sub.to_owned()).await;
+    let result = user_repo
+        .update_user_with_email(claims.sub.to_owned(), user.into_inner())
+        .await;
 
     result.map(|user| HttpResponse::Ok().json(user))
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod api_docs;
+pub mod resources;
 mod configuration;
 
 pub use configuration::{AppState, Config};

--- a/src/utils/resources.rs
+++ b/src/utils/resources.rs
@@ -1,0 +1,22 @@
+use crypto::digest::Digest;
+use crypto::sha2::Sha256;
+
+pub fn create_hash(s: String) -> String {
+    let mut sha = Sha256::new();
+    sha.input_str(&s);
+    sha.result_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_hash() {
+        let hash = create_hash("my_pass".to_string());
+        assert_eq!(
+            hash,
+            "9255fbc8fad0656dbe8190ae4025825ad7ceb8eec76428be00476bbda5ba390c"
+        );
+    }
+}


### PR DESCRIPTION
Supporting updating the information of your user. I feel like this is kind of messy at the moment as I am not super confident with Rust, I added a TODO for me to go back and revisit the logic that does the updating. Tried digging in the `bson` and `mongodb` docs but couldn't see anything about partial updates with optional values.


Closes https://github.com/egilsster/wodbook-api/issues/28