### PR TITLE
feat: patch endpoints for workouts and movements

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -74,7 +74,7 @@ paths:
         - users
       responses:
         201:
-          description: OK. Returns user information.
+          description: Returns user information.
           content:
             application/json:
               schema:
@@ -86,13 +86,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
     patch:
-      summary: Updates information about the logged in user.
+      summary: Updates information about the logged in user and returns the updated user model.
       operationId: updateUser
       tags:
         - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateUser"
       responses:
         200:
-          description: OK. User has been updated and returns user information.
+          description: User has been updated and returns user information.
           content:
             application/json:
               schema:
@@ -111,7 +117,7 @@ paths:
         - workouts
       responses:
         200:
-          description: OK. Lists all workouts.
+          description: Lists all workouts.
           content:
             application/json:
               schema:
@@ -129,13 +135,49 @@ paths:
               $ref: "#/components/schemas/workout"
       responses:
         201:
-          description: Created. Creates a new workout and returns it.
+          description: Creates a new workout and returns it.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/workout"
         409:
-          description: Conflict. Resource with same unique identity already exists.
+          description: Resource with same unique identity already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        422:
+          description: Unprocessable entity. Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    patch:
+      summary: Update an existing workout.
+      operationId: updateWorkout
+      tags:
+        - workouts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateWorkout"
+      responses:
+        200:
+          description: Updates the workout and returns it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/workout"
+        409:
+          description: Resource with same unique identity already exists.
           content:
             application/json:
               schema:
@@ -167,7 +209,7 @@ paths:
             type: string
       responses:
         200:
-          description: OK. Returns workout with {id}.
+          description: Returns workout with {id}.
           content:
             application/json:
               schema:
@@ -179,7 +221,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
         404:
-          description: Not found. Could not find the workout with {id}.
+          description: Could not find the workout with {id}.
           content:
             application/json:
               schema:
@@ -204,7 +246,7 @@ paths:
               $ref: "#/components/schemas/workoutScore"
       responses:
         200:
-          description: OK. Returns workout score.
+          description: Returns workout score.
           content:
             application/json:
               schema:
@@ -216,7 +258,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
         404:
-          description: Not found. Could not find the workout with {id}.
+          description: Could not find the workout with {id}.
           content:
             application/json:
               schema:
@@ -229,7 +271,7 @@ paths:
         - movements
       responses:
         200:
-          description: OK. Lists all movements.
+          description: Lists all movements.
           content:
             application/json:
               schema:
@@ -247,13 +289,49 @@ paths:
               $ref: "#/components/schemas/movement"
       responses:
         201:
-          description: Created. Creates a new movement and returns it.
+          description: Creates a new movement and returns it.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/movement"
         409:
-          description: Conflict. Resource with same unique identity already exists.
+          description: Resource with same unique identity already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        422:
+          description: Unprocessable entity. Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    post:
+      summary: Updates an existing movement.
+      operationId: updateMovement
+      tags:
+        - movements
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateMovement"
+      responses:
+        200:
+          description: Updates the movement and returns it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/movement"
+        409:
+          description: Resource with same unique identity already exists.
           content:
             application/json:
               schema:
@@ -285,7 +363,7 @@ paths:
             type: string
       responses:
         200:
-          description: OK. Returns movement with {id}.
+          description: Returns movement with {id}.
           content:
             application/json:
               schema:
@@ -297,7 +375,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
         404:
-          description: Not found. Could not find the movement with {id}.
+          description: Could not find the movement with {id}.
           content:
             application/json:
               schema:
@@ -322,7 +400,7 @@ paths:
               $ref: "#/components/schemas/movementScore"
       responses:
         200:
-          description: OK. Returns movement score.
+          description: Returns movement score.
           content:
             application/json:
               schema:
@@ -334,7 +412,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
         404:
-          description: Not found. Could not find the movement with {id}.
+          description: Could not find the movement with {id}.
           content:
             application/json:
               schema:
@@ -362,6 +440,30 @@ components:
         last_name:
           type: string
         email:
+          type: string
+        password:
+          type: string
+          description: Hash of the password.
+        box_name:
+          type: string
+          description: The box name, if the user associates with one.
+        height:
+          type: number
+        weight:
+          type: number
+        date_of_birth:
+          type: string
+          format: yyyy-mm-dd
+        avatar_url:
+          type: string
+          description: An image that the user adds to his account.
+    updateUser:
+      type: object
+      description: The update user model.
+      properties:
+        first_name:
+          type: string
+        last_name:
           type: string
         password:
           type: string
@@ -417,6 +519,16 @@ components:
           type: string
           format: date
           readOnly: true
+    updateWorkout:
+      type: object
+      description: The workout update model.
+      properties:
+        name:
+          type: string
+          description: The name of this workout.
+        description:
+          type: string
+          description: Description of the workout.
     workoutScore:
       type: object
       description: Score for a workout.
@@ -478,6 +590,16 @@ components:
           type: string
           format: date
           readOnly: true
+    updateMovement:
+      type: object
+      description: The movement update model.
+      properties:
+        name:
+          type: string
+          description: The name of this movement.
+        description:
+          type: string
+          description: Description of the workout.
     movementScore:
       type: object
       description: Score for a movement.

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -312,7 +312,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
-    post:
+    patch:
       summary: Updates an existing movement.
       operationId: updateMovement
       tags:

--- a/component_tests/movement.test.ts
+++ b/component_tests/movement.test.ts
@@ -197,6 +197,174 @@ describe("/v1/movements/", () => {
     });
   });
 
+  describe("updating movements", () => {
+    it("should be able to movement name", async (done) => {
+      const movement = {
+        name: "Sholder Press",
+        measurement: "weight",
+      };
+
+      try {
+        const res1: MovementResponse = await request.post("/movements/", {
+          ...reqOpts,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${userToken}`,
+          },
+          body: movement,
+        });
+
+        expect(res1.statusCode).toBe(HttpStatus.CREATED);
+        expect(res1.body).toHaveProperty("movement_id");
+        const movementId = res1.body.movement_id;
+        expect(res1.body).toHaveProperty("name", movement.name);
+        expect(res1.body).toHaveProperty("measurement", movement.measurement);
+        expect(res1.body).toHaveProperty("global", false);
+        expect(res1.body).toHaveProperty("created_at");
+        expect(res1.body).toHaveProperty("updated_at");
+
+        const res2: MovementResponse = await request.get(
+          `/movements/${movementId}`,
+          {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${userToken}`,
+            },
+          }
+        );
+
+        expect(res2.statusCode).toBe(HttpStatus.OK);
+        expect(res2.body).toHaveProperty("movement_id");
+        expect(res2.body).toHaveProperty("name", movement.name);
+        expect(res2.body).toHaveProperty("measurement", movement.measurement);
+        expect(res2.body).toHaveProperty("global", false);
+        expect(res2.body).toHaveProperty("created_at");
+        expect(res2.body).toHaveProperty("updated_at");
+        expect(res2.body.created_at).toEqual(res2.body.updated_at);
+
+        const res3: MovementResponse = await request.patch(
+          `/movements/${movementId}`,
+          {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${userToken}`,
+            },
+            body: {
+              name: "Shoulder Press",
+            },
+          }
+        );
+
+        expect(res3.statusCode).toBe(HttpStatus.OK);
+        expect(res3.body).toHaveProperty("movement_id");
+        expect(res3.body).toHaveProperty("name", "Shoulder Press");
+        expect(res3.body).toHaveProperty("measurement", movement.measurement);
+        expect(res3.body).toHaveProperty("global", false);
+        expect(res3.body).toHaveProperty("created_at");
+        expect(res3.body).toHaveProperty("updated_at");
+        expect(res3.body.created_at).not.toEqual(res3.body.updated_at);
+
+        const res4: MovementResponse = await request.get(
+          `/movements/${movementId}`,
+          {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${userToken}`,
+            },
+          }
+        );
+
+        expect(res4.statusCode).toBe(HttpStatus.OK);
+        expect(res4.body).toHaveProperty("movement_id");
+        expect(res4.body).toHaveProperty("name", "Shoulder Press");
+        expect(res4.body).toHaveProperty("measurement", movement.measurement);
+        expect(res4.body).toHaveProperty("global", false);
+        expect(res4.body).toHaveProperty("created_at");
+        expect(res4.body).toHaveProperty("updated_at");
+        expect(res4.body.created_at).not.toEqual(res4.body.updated_at);
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it("should get 409 Conflict if you set to a name that already exists", async (done) => {
+      const movement = {
+        name: "Shoulder Press",
+        measurement: "weight",
+      };
+
+      try {
+        const res1: MovementResponse = await request.post("/movements/", {
+          ...reqOpts,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${userToken}`,
+          },
+          body: {
+            name: "Sholder Press",
+            measurement: "weight",
+          },
+        });
+
+        expect(res1.statusCode).toBe(HttpStatus.CREATED);
+        expect(res1.body).toHaveProperty("movement_id");
+        const movementId = res1.body.movement_id;
+        expect(res1.body).toHaveProperty("name", "Sholder Press");
+
+        const res2: MovementResponse = await request.post("/movements/", {
+          ...reqOpts,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${userToken}`,
+          },
+          body: movement,
+        });
+
+        expect(res2.statusCode).toBe(HttpStatus.CREATED);
+        expect(res2.body).toHaveProperty("name", "Shoulder Press");
+
+        const res3: MovementResponse = await request.patch(
+          `/movements/${movementId}`,
+          {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${userToken}`,
+            },
+            body: {
+              name: "Shoulder Press",
+            },
+          }
+        );
+
+        expect(res3.statusCode).toBe(HttpStatus.CONFLICT);
+
+        const res4: MovementResponse = await request.get(
+          `/movements/${movementId}`,
+          {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${userToken}`,
+            },
+          }
+        );
+
+        expect(res4.statusCode).toBe(HttpStatus.OK);
+        expect(res4.body).toHaveProperty("name", "Sholder Press");
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
   describe("movement scores", () => {
     it("should create a new movement and add a score for it", async (done) => {
       const movement = {
@@ -337,7 +505,7 @@ describe("/v1/movements/", () => {
 
   describe("global movements", () => {
     it("should return movements created by other users if they are marked as global", async (done) => {
-      const wod = {
+      const movement = {
         name: "Snatch",
         measurement: "weight",
         global: true,
@@ -350,14 +518,14 @@ describe("/v1/movements/", () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${adminToken}`,
           },
-          body: wod,
+          body: movement,
         });
 
         expect(res1.statusCode).toBe(HttpStatus.CREATED);
         expect(res1.body).toHaveProperty("movement_id");
         const movementId = res1.body.movement_id;
-        expect(res1.body).toHaveProperty("name", wod.name);
-        expect(res1.body).toHaveProperty("measurement", wod.measurement);
+        expect(res1.body).toHaveProperty("name", movement.name);
+        expect(res1.body).toHaveProperty("measurement", movement.measurement);
         expect(res1.body).toHaveProperty("global", true);
         expect(res1.body).toHaveProperty("created_at");
         expect(res1.body).toHaveProperty("updated_at");
@@ -375,8 +543,8 @@ describe("/v1/movements/", () => {
 
         expect(res2.statusCode).toBe(HttpStatus.OK);
         expect(res2.body).toHaveProperty("movement_id");
-        expect(res2.body).toHaveProperty("name", wod.name);
-        expect(res2.body).toHaveProperty("measurement", wod.measurement);
+        expect(res2.body).toHaveProperty("name", movement.name);
+        expect(res2.body).toHaveProperty("measurement", movement.measurement);
         expect(res2.body).toHaveProperty("global", true);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
@@ -394,8 +562,8 @@ describe("/v1/movements/", () => {
 
         expect(res3.statusCode).toBe(HttpStatus.OK);
         expect(res2.body).toHaveProperty("movement_id");
-        expect(res2.body).toHaveProperty("name", wod.name);
-        expect(res2.body).toHaveProperty("measurement", wod.measurement);
+        expect(res2.body).toHaveProperty("name", movement.name);
+        expect(res2.body).toHaveProperty("measurement", movement.measurement);
         expect(res2.body).toHaveProperty("global", true);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");

--- a/component_tests/types/movement.d.ts
+++ b/component_tests/types/movement.d.ts
@@ -6,7 +6,7 @@ type MovementData = {
   global: boolean;
   scores: any[]; // TODO(egilsster): add scores for movements
   created_at: string;
-  update_at: string;
+  updated_at: string;
 };
 
 type ManyMovementsData = {

--- a/component_tests/types/workout.d.ts
+++ b/component_tests/types/workout.d.ts
@@ -7,7 +7,7 @@ type WorkoutData = {
   global: boolean;
   scores: any[]; // TODO(egilsster): add scores for workouts
   created_at: string;
-  update_at: string;
+  updated_at: string;
 };
 
 type ManyWorkoutsData = {

--- a/component_tests/user.test.ts
+++ b/component_tests/user.test.ts
@@ -22,7 +22,7 @@ describe("/users", () => {
     });
   });
 
-  beforeEach(async () => {
+  afterEach(async () => {
     const db = mongoClient.db();
     const coll = db.collection("users");
     await coll.deleteMany({});

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -68,6 +68,11 @@ pub struct CreateMovement {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct UpdateMovement {
+    pub name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CreateMovementScore {
     pub score: String,
     #[serde(default = "default_as_one")]

--- a/src/models/workout.rs
+++ b/src/models/workout.rs
@@ -64,6 +64,12 @@ pub struct CreateWorkout {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct UpdateWorkout {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CreateWorkoutScore {
     pub score: String,
     pub rx: bool,


### PR DESCRIPTION
Patch endpoints for `<workouts|movements>/:id` to perform updates. The allowed properties are in the api-docs.

Closes https://github.com/egilsster/wodbook-api/issues/132