### PR TITLE
fix: proper database filter

### DIFF
--- a/component_tests/workout.test.ts
+++ b/component_tests/workout.test.ts
@@ -92,6 +92,23 @@ describe("/v1/workouts", () => {
       };
 
       try {
+        const placeholder_wod = {
+          name: "A placeholder",
+          measurement: "time",
+          description: "Do some work",
+          global: true,
+        };
+        const res0: WorkoutResponse = await request.post("/workouts/", {
+          ...reqOpts,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${adminToken}`,
+          },
+          body: placeholder_wod,
+        });
+
+        expect(res0.statusCode).toBe(HttpStatus.CREATED);
+
         const res1: WorkoutResponse = await request.post("/workouts/", {
           ...reqOpts,
           headers: {
@@ -142,15 +159,17 @@ describe("/v1/workouts", () => {
         expect(res3.statusCode).toBe(HttpStatus.OK);
         expect(res3.body).toHaveProperty("data");
         const workouts = res3.body.data;
-        expect(workouts).toHaveProperty("length");
-        const [workout1] = workouts;
-        expect(workout1).toHaveProperty("workout_id");
-        expect(workout1).toHaveProperty("name", wod.name);
-        expect(workout1).toHaveProperty("description", wod.description);
-        expect(workout1).toHaveProperty("measurement", wod.measurement);
-        expect(workout1).toHaveProperty("global", false);
-        expect(workout1).toHaveProperty("created_at");
-        expect(workout1).toHaveProperty("updated_at");
+        expect(workouts).toHaveProperty("length", 2);
+        const [workout1, workout2] = workouts;
+        expect(workout1).toHaveProperty("name", placeholder_wod.name);
+        expect(workout1).toHaveProperty("global", true);
+        expect(workout2).toHaveProperty("workout_id");
+        expect(workout2).toHaveProperty("name", wod.name);
+        expect(workout2).toHaveProperty("description", wod.description);
+        expect(workout2).toHaveProperty("measurement", wod.measurement);
+        expect(workout2).toHaveProperty("global", false);
+        expect(workout2).toHaveProperty("created_at");
+        expect(workout2).toHaveProperty("updated_at");
         done();
       } catch (err) {
         done(err);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_docs;
 mod configuration;
+pub mod query_utils;
 pub mod resources;
 
 pub use configuration::{AppState, Config};

--- a/src/utils/query_utils.rs
+++ b/src/utils/query_utils.rs
@@ -1,0 +1,117 @@
+use bson::{doc, Document};
+
+/// Creates a query that gets all documents that have
+/// the given `user_id` as well as global resources.
+///
+/// ## Example
+///
+/// ```
+/// let query = for_many("user-id");
+/// ```
+pub fn for_many(user_id: &str) -> Document {
+    doc! {
+        "$or": [
+            { "user_id": user_id },
+            { "global": true }
+        ]
+    }
+}
+
+/// Creates a query that uses the provided filter and only returns
+/// resources owned by `user_id` or global resources. The `filter`
+/// is a bson document with some additional restrictions.
+///
+/// ## Examples
+///
+/// ```
+/// let query = for_many_with_filter(doc! { "resource_id": "resource-id" }, "user-id");
+/// ```
+pub fn for_many_with_filter(filter: Document, user_id: &str) -> Document {
+    doc! {
+        "$and": [
+            filter,
+            {
+                "$or": [
+                    { "user_id": user_id },
+                    { "global": true }
+                ]
+            }
+        ]
+    }
+}
+
+/// Creates a query to get a single document decided by the filter.
+/// This query can only get documents owned by `user_id` or global
+/// documents.
+///
+/// ## Example
+///
+/// ```
+/// let query = for_one(doc! { "resource_id": "resource-id" }, "user-id");
+/// ```
+pub fn for_one(filter: Document, user_id: &str) -> Document {
+    doc! {
+        "$and": [
+            filter,
+            {
+                "$or": [
+                    { "user_id": user_id },
+                    { "global": true }
+                ]
+            }
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_for_many() {
+        let res = for_many("user_id");
+        let expected = doc! {
+            "$or": [
+                { "user_id": "user_id" },
+                { "global": true }
+            ]
+        };
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_for_many_with_filter() {
+        let filter = doc! { "resource_id": "resource_id" };
+        let res = for_many_with_filter(filter, "user_id");
+        let expected = doc! {
+            "$and": [
+                { "resource_id": "resource_id" },
+                {
+                    "$or": [
+                        { "user_id": "user_id" },
+                        { "global": true }
+                    ]
+                }
+            ]
+        };
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_for_one() {
+        let filter = doc! { "resource_id": "resource_id" };
+        let res = for_one(filter, "user_id");
+        let expected = doc! {
+            "$and": [
+                { "resource_id": "resource_id" },
+            {
+                "$or": [
+                    { "user_id": "user_id" },
+                    { "global": true }
+                ]
+            }
+        ]
+        };
+        assert_eq!(res, expected);
+    }
+}


### PR DESCRIPTION
The query was always returning the first value in the database and the filter wasn't correct. This PR creates query utilities to make it simpler to create bigger queries for filters and the standard user scope.

Also, changes to what is passed around was creating a new string for each scope instead of just passing around a pointer to the value, since it isnt modified.