### PR TITLE
revert: "ci: switch to coveralls (#148)"

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 1
+  round: down
+  range: "70...100"
+
+  status:
+    project: true
+    patch: true
+    changes: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: yes
+      macro: no
+
+comment: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,10 +65,13 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         env:
           CARGO_INCREMENTAL: 0
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           version: 0.13.3
-          args: --all --ciserver github-ci --coveralls $COVERALLS_REPO_TOKEN -- --test-threads 1
+          args: --all -- --test-threads 1
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build status](https://github.com/egilsster/wodbook-api/workflows/build/badge.svg?branch=main)
 ![Audit status](https://github.com/egilsster/wodbook-api/workflows/audit/badge.svg?branch=main)
-[![Coverage Status](https://coveralls.io/repos/github/egilsster/wodbook-api/badge.svg?branch=main)](https://coveralls.io/github/egilsster/wodbook-api?branch=main)
+[![codecov](https://codecov.io/gh/egilsster/wodbook-api/branch/main/graph/badge.svg)](https://codecov.io/gh/egilsster/wodbook-api)
 
 Back-end for the [wodbook-app](https://github.com/egilsster/wodbook-app).
 


### PR DESCRIPTION
Coveralls is not picking up anything from my coverage report and it does not show any errors or anything 😕

The codecov upload seems to be fixed now so will go back to that.