### PR TITLE
feat: support deleting scores

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -377,6 +377,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
+    delete:
+      summary: Deletes a specific workout score.
+      operationId: deleteWorkoutScoreById
+      tags:
+        - workouts
+      parameters:
+        - name: workoutId
+          in: path
+          required: true
+          description: Workout identifier
+          schema:
+            type: string
+        - name: workoutScoreId
+          in: path
+          required: true
+          description: Workout score identifier
+          schema:
+            type: string
+      responses:
+        204:
+          description: Score deleted successfully.
+        403:
+          description: Forbidden. User is not authorized to delete workout score.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        404:
+          description: Could not find the workout or workout score.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
   /movements/:
     get:
       summary: List all movements.
@@ -593,6 +632,45 @@ paths:
                 $ref: "#/components/schemas/movementScore"
         403:
           description: Forbidden. User is not authorized to update movement score.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        404:
+          description: Could not find the movement or movement score.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    delete:
+      summary: Deletes a specific movement score.
+      operationId: deleteMovementScoreById
+      tags:
+        - movements
+      parameters:
+        - name: movementId
+          in: path
+          required: true
+          description: Movement identifier
+          schema:
+            type: string
+        - name: movementScoreId
+          in: path
+          required: true
+          description: Movement score identifier
+          schema:
+            type: string
+      responses:
+        204:
+          description: Score deleted successfully.
+        403:
+          description: Forbidden. User is not authorized to delete movement score.
           content:
             application/json:
               schema:

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -56,6 +56,17 @@ describe("/users/mywod", () => {
     });
   });
 
+  beforeEach(async () => {
+    await db.collection("workouts").deleteMany({});
+    await db.collection("workoutscores").deleteMany({});
+    await db.collection("movements").deleteMany({});
+    await db.collection("movementscores").deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoClient.close();
+  });
+
   describe("/mywod", () => {
     it("should migrate data from a mywod backup to the user", async (done) => {
       try {

--- a/src/repositories/movement_repository.rs
+++ b/src/repositories/movement_repository.rs
@@ -378,6 +378,26 @@ impl MovementRepository {
             ));
         }
 
-        Ok(res.unwrap())
+        res
+    }
+
+    pub async fn delete_movement_score_by_id(
+        &self,
+        user_id: &str,
+        movement_id: &str,
+        movement_score_id: &str,
+    ) -> Result<(), AppError> {
+        // Ensure the score exists for the user
+        self.get_movement_score_by_id(user_id, movement_id, movement_score_id)
+            .await?;
+
+        let query = query_utils::for_one(doc! { "movement_score_id": movement_score_id }, user_id);
+        let delete_result = self.get_score_collection().delete_one(query, None).await;
+
+        if let Err(delete_result) = delete_result {
+            return Err(AppError::Internal(delete_result.to_string()));
+        }
+
+        Ok(())
     }
 }

--- a/src/repositories/workout_repository.rs
+++ b/src/repositories/workout_repository.rs
@@ -389,4 +389,24 @@ impl WorkoutRepository {
 
         res
     }
+
+    pub async fn delete_workout_score_by_id(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+        workout_score_id: &str,
+    ) -> Result<(), AppError> {
+        // Ensure the score exists for the user
+        self.get_workout_score_by_id(user_id, workout_id, workout_score_id)
+            .await?;
+
+        let query = query_utils::for_one(doc! { "workout_score_id": workout_score_id }, user_id);
+        let delete_result = self.get_score_collection().delete_one(query, None).await;
+
+        if let Err(delete_result) = delete_result {
+            return Err(AppError::Internal(delete_result.to_string()));
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Endpoint to delete a score by its id, required the workout id as well.

Closes https://github.com/egilsster/wodbook-api/issues/165