### PR TITLE
refactor: get token from register endpoint

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -27,6 +27,12 @@ paths:
       operationId: loginUser
       tags:
         - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/login"
       responses:
         "200":
           description: Login successful.
@@ -59,7 +65,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/user"
+                $ref: "#/components/schemas/token"
         "400":
           description: Registration unsuccessful.
   /users/me/:
@@ -695,6 +701,14 @@ components:
       properties:
         token:
           type: string
+    login:
+      type: object
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+          description: Hash of the password.
     user:
       type: object
       properties:

--- a/integration_tests/movement.test.ts
+++ b/integration_tests/movement.test.ts
@@ -18,7 +18,7 @@ describe("/v1/movements/", () => {
   let adminToken: string;
 
   const login = async ({ email, password }: LoginPayload) => {
-    const res1: LoginResponse = await request.post("users/login", {
+    const res1: TokenResponse = await request.post("users/login", {
       ...reqOpts,
       headers: {
         "Content-Type": "application/json",

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -22,7 +22,7 @@ describe("/users/mywod", () => {
   let adminToken: string;
 
   const login = async ({ email, password }: LoginPayload) => {
-    const res1: LoginResponse = await request.post("users/login", {
+    const res1: TokenResponse = await request.post("users/login", {
       ...reqOpts,
       headers: {
         "Content-Type": "application/json",

--- a/integration_tests/types/user.d.ts
+++ b/integration_tests/types/user.d.ts
@@ -2,7 +2,7 @@ type LoginData = {
   token: string;
 };
 
-declare type LoginResponse = {
+declare type TokenResponse = {
   statusCode: number;
   body: LoginData;
 };

--- a/integration_tests/user.test.ts
+++ b/integration_tests/user.test.ts
@@ -37,7 +37,7 @@ describe("/users", () => {
     describe("POST", () => {
       it("should create new user and login", async (done) => {
         try {
-          const res1 = await request.post("users/register", {
+          const res1: TokenResponse = await request.post("users/register", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -55,17 +55,9 @@ describe("/users", () => {
           });
 
           expect(res1.statusCode).toBe(HttpStatus.CREATED);
-          expect(res1.body).toHaveProperty("user_id");
-          expect(res1.body).toHaveProperty("first_name", "Juliette");
-          expect(res1.body).toHaveProperty("last_name", "Danielle");
-          expect(res1.body).toHaveProperty("box_name", "The Room");
-          expect(res1.body).toHaveProperty("email", "lisa@the-room.com");
-          expect(res1.body).toHaveProperty("height", 168);
-          expect(res1.body).toHaveProperty("weight", 61000);
-          expect(res1.body).toHaveProperty("date_of_birth", "1980-12-08");
-          expect(res1.body).not.toHaveProperty("password");
+          expect(res1.body).toHaveProperty("token");
 
-          const res2 = await request.post("users/login", {
+          const res2: TokenResponse = await request.post("users/login", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -79,6 +71,27 @@ describe("/users", () => {
           expect(res2.statusCode).toBe(HttpStatus.OK);
           expect(res2.body).toHaveProperty("token");
           expect(res2.body.token.startsWith("ey")).toBe(true);
+
+          const token = res2.body.token;
+
+          const res3: UserResponse = await request.get("users/me", {
+            ...reqOpts,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          expect(res3.statusCode).toBe(HttpStatus.OK);
+          expect(res3.body).toHaveProperty("user_id");
+          expect(res3.body).toHaveProperty("first_name", "Juliette");
+          expect(res3.body).toHaveProperty("last_name", "Danielle");
+          expect(res3.body).toHaveProperty("box_name", "The Room");
+          expect(res3.body).toHaveProperty("email", "lisa@the-room.com");
+          expect(res3.body).toHaveProperty("height", 168);
+          expect(res3.body).toHaveProperty("weight", 61000);
+          expect(res3.body).toHaveProperty("date_of_birth", "1980-12-08");
+          expect(res3.body).toHaveProperty("password");
           done();
         } catch (err) {
           done(err);
@@ -195,32 +208,9 @@ describe("/users", () => {
           });
 
           expect(res1.statusCode).toBe(HttpStatus.CREATED);
-          expect(res1.body).toHaveProperty("user_id");
-          expect(res1.body).toHaveProperty("first_name", user.first_name);
-          expect(res1.body).toHaveProperty("last_name", user.last_name);
-          expect(res1.body).toHaveProperty("box_name", user.box_name);
-          expect(res1.body).toHaveProperty("email", user.email);
-          expect(res1.body).toHaveProperty("height", user.height);
-          expect(res1.body).toHaveProperty("weight", user.weight);
-          expect(res1.body).toHaveProperty("date_of_birth", user.date_of_birth);
-          expect(res1.body).not.toHaveProperty("password");
+          const { token } = res1.body;
 
-          const res2 = await request.post("users/login", {
-            ...reqOpts,
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: {
-              email: user.email,
-              password: user.password,
-            },
-          });
-
-          expect(res2.statusCode).toBe(HttpStatus.OK);
-          expect(res2.body).toHaveProperty("token");
-          const { token } = res2.body;
-
-          const res3 = await request.get("users/me", {
+          const res2 = await request.get("users/me", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -228,18 +218,18 @@ describe("/users", () => {
             },
           });
 
-          expect(res3.statusCode).toBe(HttpStatus.OK);
-          expect(res3.body).toHaveProperty("user_id");
-          expect(res3.body).toHaveProperty("first_name", user.first_name);
-          expect(res3.body).toHaveProperty("last_name", user.last_name);
-          expect(res3.body).toHaveProperty("box_name", user.box_name);
-          expect(res3.body).toHaveProperty("email", user.email);
-          expect(res3.body).toHaveProperty("height", user.height);
-          expect(res3.body).toHaveProperty("weight", user.weight);
-          expect(res3.body).toHaveProperty("date_of_birth", user.date_of_birth);
-          expect(res3.body).toHaveProperty("password");
+          expect(res2.statusCode).toBe(HttpStatus.OK);
+          expect(res2.body).toHaveProperty("user_id");
+          expect(res2.body).toHaveProperty("first_name", user.first_name);
+          expect(res2.body).toHaveProperty("last_name", user.last_name);
+          expect(res2.body).toHaveProperty("box_name", user.box_name);
+          expect(res2.body).toHaveProperty("email", user.email);
+          expect(res2.body).toHaveProperty("height", user.height);
+          expect(res2.body).toHaveProperty("weight", user.weight);
+          expect(res2.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res2.body).toHaveProperty("password");
 
-          const res4 = await request.patch("users/me", {
+          const res3 = await request.patch("users/me", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -252,20 +242,20 @@ describe("/users", () => {
             },
           });
 
-          expect(res4.statusCode).toBe(HttpStatus.OK);
+          expect(res3.statusCode).toBe(HttpStatus.OK);
           // Verify new data
-          expect(res4.body).toHaveProperty("first_name", "new first_name");
-          expect(res4.body).toHaveProperty("last_name", "new last_name");
-          expect(res4.body).toHaveProperty("box_name", "new box_name");
+          expect(res3.body).toHaveProperty("first_name", "new first_name");
+          expect(res3.body).toHaveProperty("last_name", "new last_name");
+          expect(res3.body).toHaveProperty("box_name", "new box_name");
           // Verify that unchanged data remains there
-          expect(res4.body).toHaveProperty("email", user.email);
-          expect(res4.body).toHaveProperty("height", user.height);
-          expect(res4.body).toHaveProperty("weight", user.weight);
-          expect(res4.body).toHaveProperty("date_of_birth", user.date_of_birth);
-          expect(res4.body).toHaveProperty("password");
+          expect(res3.body).toHaveProperty("email", user.email);
+          expect(res3.body).toHaveProperty("height", user.height);
+          expect(res3.body).toHaveProperty("weight", user.weight);
+          expect(res3.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res3.body).toHaveProperty("password");
 
           // Verify that the GET requests returns the same data
-          const res5 = await request.get("users/me", {
+          const res4 = await request.get("users/me", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -273,16 +263,16 @@ describe("/users", () => {
             },
           });
 
-          expect(res5.statusCode).toBe(HttpStatus.OK);
-          expect(res5.body).toHaveProperty("user_id");
-          expect(res5.body).toHaveProperty("first_name", "new first_name");
-          expect(res5.body).toHaveProperty("last_name", "new last_name");
-          expect(res5.body).toHaveProperty("box_name", "new box_name");
-          expect(res5.body).toHaveProperty("email", user.email);
-          expect(res5.body).toHaveProperty("height", user.height);
-          expect(res5.body).toHaveProperty("weight", user.weight);
-          expect(res5.body).toHaveProperty("date_of_birth", user.date_of_birth);
-          expect(res5.body).toHaveProperty("password");
+          expect(res4.statusCode).toBe(HttpStatus.OK);
+          expect(res4.body).toHaveProperty("user_id");
+          expect(res4.body).toHaveProperty("first_name", "new first_name");
+          expect(res4.body).toHaveProperty("last_name", "new last_name");
+          expect(res4.body).toHaveProperty("box_name", "new box_name");
+          expect(res4.body).toHaveProperty("email", user.email);
+          expect(res4.body).toHaveProperty("height", user.height);
+          expect(res4.body).toHaveProperty("weight", user.weight);
+          expect(res4.body).toHaveProperty("date_of_birth", user.date_of_birth);
+          expect(res4.body).toHaveProperty("password");
 
           done();
         } catch (err) {
@@ -312,34 +302,11 @@ describe("/users", () => {
           });
 
           expect(res1.statusCode).toBe(HttpStatus.CREATED);
-          expect(res1.body).toHaveProperty("user_id");
-          expect(res1.body).toHaveProperty("first_name", user.first_name);
-          expect(res1.body).toHaveProperty("last_name", user.last_name);
-          expect(res1.body).toHaveProperty("box_name", user.box_name);
-          expect(res1.body).toHaveProperty("email", user.email);
-          expect(res1.body).toHaveProperty("height", user.height);
-          expect(res1.body).toHaveProperty("weight", user.weight);
-          expect(res1.body).toHaveProperty("date_of_birth", user.date_of_birth);
-          expect(res1.body).not.toHaveProperty("password");
-
-          const res2 = await request.post("users/login", {
-            ...reqOpts,
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: {
-              email: user.email,
-              password: user.password,
-            },
-          });
-
-          expect(res2.statusCode).toBe(HttpStatus.OK);
-          expect(res2.body).toHaveProperty("token");
-          const { token } = res2.body;
+          const { token } = res1.body;
 
           const new_pass = "my-new-password";
 
-          const res3 = await request.patch("users/me", {
+          const res2 = await request.patch("users/me", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -350,10 +317,10 @@ describe("/users", () => {
             },
           });
 
-          expect(res3.statusCode).toBe(HttpStatus.OK);
+          expect(res2.statusCode).toBe(HttpStatus.OK);
 
           // Verify that login works with the new password
-          const res4 = await request.post("users/login", {
+          const res3 = await request.post("users/login", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -364,11 +331,11 @@ describe("/users", () => {
             },
           });
 
-          expect(res4.statusCode).toBe(HttpStatus.OK);
-          expect(res4.body).toHaveProperty("token");
+          expect(res3.statusCode).toBe(HttpStatus.OK);
+          expect(res3.body).toHaveProperty("token");
 
           // Verify that login does NOT work with the old password
-          const res5 = await request.post("users/login", {
+          const res4 = await request.post("users/login", {
             ...reqOpts,
             headers: {
               "Content-Type": "application/json",
@@ -379,7 +346,7 @@ describe("/users", () => {
             },
           });
 
-          expect(res5.statusCode).toBe(HttpStatus.BAD_REQUEST);
+          expect(res4.statusCode).toBe(HttpStatus.BAD_REQUEST);
 
           done();
         } catch (err) {

--- a/integration_tests/workout.test.ts
+++ b/integration_tests/workout.test.ts
@@ -18,7 +18,7 @@ describe("/v1/workouts", () => {
   let adminToken: string;
 
   const login = async ({ email, password }: LoginPayload) => {
-    const res1: LoginResponse = await request.post("users/login", {
+    const res1: TokenResponse = await request.post("users/login", {
       ...reqOpts,
       headers: {
         "Content-Type": "application/json",

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -6,7 +6,7 @@ pub struct HealthResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct LoginResponse {
+pub struct TokenResponse {
     pub token: String,
 }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -6,6 +6,14 @@ fn default_as_false() -> bool {
     false
 }
 
+fn default_as_empty_string() -> String {
+    "".to_string()
+}
+
+fn default_as_zero() -> i32 {
+    0
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct User {
     pub user_id: String,
@@ -59,14 +67,22 @@ pub struct Claims {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateUser {
     pub email: String,
+    #[serde(default = "default_as_empty_string")]
     pub password: String,
+    #[serde(default = "default_as_empty_string")]
     pub first_name: String,
+    #[serde(default = "default_as_empty_string")]
     pub last_name: String,
+    #[serde(default = "default_as_empty_string")]
     pub date_of_birth: String,
+    #[serde(default = "default_as_zero")]
     pub height: i32,
+    #[serde(default = "default_as_zero")]
     pub weight: i32,
+    #[serde(default = "default_as_empty_string")]
     pub box_name: String,
-    pub avatar_url: Option<String>,
+    #[serde(default = "default_as_empty_string")]
+    pub avatar_url: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -1,5 +1,4 @@
 use crate::errors::AppError;
-use crate::models::response::{LoginResponse, UserResponse};
 use crate::models::user::{Claims, CreateUser, Login, UpdateUser, User};
 use crate::utils::{resources, Config};
 
@@ -14,29 +13,38 @@ pub struct UserRepository {
     pub mongo_client: Client,
 }
 
+/// Generates a JWT based on user data and if the user wants to stay logged in (makes it expire in a year).
+fn gen_token(user: User, email: &str, remember_me: bool) -> Result<String, AppError> {
+    let config = Config::from_env().unwrap();
+    let key = config.auth.secret.as_bytes();
+
+    let date = if !remember_me {
+        Utc::now() + Duration::hours(1)
+    } else {
+        Utc::now() + Duration::days(365)
+    };
+
+    let my_claims = Claims {
+        sub: email.to_owned(),
+        exp: date.timestamp() as usize,
+        admin: user.admin,
+        user_id: user.user_id,
+    };
+    let token = encode(
+        &Header::default(),
+        &my_claims,
+        &EncodingKey::from_secret(key),
+    )
+    .unwrap();
+    Ok(token)
+}
+
 impl UserRepository {
     fn get_collection(&self) -> Collection {
         let config = Config::from_env().unwrap();
         let database_name = config.mongo.db_name;
         let db = self.mongo_client.database(database_name.as_str());
         db.collection(COLLECTION_NAME)
-    }
-
-    pub async fn find_user_with_id(&self, user_id: Bson) -> Result<UserResponse, AppError> {
-        let coll = self.get_collection();
-        let cursor = coll
-            .find_one(doc! { "_id":  user_id }, None)
-            .await
-            .map_err(|err| AppError::Internal(err.to_string()))?;
-
-        if cursor.is_none() {
-            return Err(AppError::NotFound("User not found".to_owned()));
-        }
-
-        match from_bson(Bson::Document(cursor.unwrap())) {
-            Ok(model) => Ok(model),
-            Err(err) => Err(AppError::Internal(err.to_string())),
-        }
     }
 
     pub async fn update_user_with_email(
@@ -86,8 +94,10 @@ impl UserRepository {
         }
     }
 
-    pub async fn login(&self, user_login: Login) -> Result<LoginResponse, AppError> {
-        let user = self.find_user_with_email(user_login.email.as_ref()).await;
+    pub async fn login(&self, user_login: Login) -> Result<String, AppError> {
+        let user_email: &str = user_login.email.as_ref();
+
+        let user = self.find_user_with_email(user_email).await;
         if user.is_err() {
             return Err(AppError::BadRequest(
                 "Check your user information (user not found)".to_string(),
@@ -101,32 +111,15 @@ impl UserRepository {
             ));
         }
 
-        let config = Config::from_env().unwrap();
-        let key = config.auth.secret.as_bytes();
+        let token = gen_token(user, user_email, user_login.remember_me).unwrap();
 
-        let date = if !user_login.remember_me {
-            Utc::now() + Duration::hours(1)
-        } else {
-            Utc::now() + Duration::days(365)
-        };
-
-        let my_claims = Claims {
-            sub: user_login.email,
-            exp: date.timestamp() as usize,
-            admin: user.admin,
-            user_id: user.user_id,
-        };
-        let token = encode(
-            &Header::default(),
-            &my_claims,
-            &EncodingKey::from_secret(key),
-        )
-        .unwrap();
-        Ok(LoginResponse { token })
+        Ok(token)
     }
 
-    pub async fn register(&self, user: CreateUser) -> Result<UserResponse, AppError> {
-        let existing_user = self.find_user_with_email(user.email.as_ref()).await;
+    pub async fn register(&self, create_user: CreateUser) -> Result<String, AppError> {
+        let user_email: &str = create_user.email.as_ref();
+
+        let existing_user = self.find_user_with_email(user_email).await;
         if existing_user.is_ok() {
             return Err(AppError::Conflict(
                 "This e-mail is using by some user, please enter another e-mail.".to_string(),
@@ -134,26 +127,79 @@ impl UserRepository {
         }
 
         let coll = self.get_collection();
-        let hash_pw = resources::create_hash(&user.password);
+        let hash_pw = resources::create_hash(&create_user.password);
         let id = uuid::Uuid::new_v4().to_string();
         let user_doc = doc! {
             "user_id": id,
-            "email": user.email,
+            "email": user_email,
             "password": hash_pw,
-            "first_name": user.first_name,
-            "last_name": user.last_name,
-            "date_of_birth": user.date_of_birth,
-            "height": user.height,
-            "weight": user.weight,
-            "box_name": user.box_name,
+            "first_name": create_user.first_name,
+            "last_name": create_user.last_name,
+            "date_of_birth": create_user.date_of_birth,
+            "height": create_user.height,
+            "weight": create_user.weight,
+            "box_name": create_user.box_name,
             "avatar_url": "",
         };
 
-        let result = coll
-            .insert_one(user_doc, None)
+        coll.insert_one(user_doc, None)
             .await
             .map_err(|err| AppError::Internal(err.to_string()))?;
 
-        self.find_user_with_id(result.inserted_id).await
+        let user = self.find_user_with_email(user_email).await?;
+        let token = gen_token(user, user_email, false).unwrap();
+
+        Ok(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dotenv::dotenv;
+
+    #[test]
+    fn test_gen_token() {
+        dotenv().ok();
+
+        let res1 = gen_token(
+            User {
+                user_id: "user_id".to_owned(),
+                email: "email".to_owned(),
+                password: "password".to_owned(),
+                admin: false,
+                first_name: "first_name".to_owned(),
+                last_name: "last_name".to_owned(),
+                date_of_birth: "date_of_birth".to_owned(),
+                height: 185,
+                weight: 85000,
+                box_name: "box_name".to_owned(),
+                avatar_url: "avatar_url".to_owned(),
+            },
+            "email",
+            false,
+        )
+        .unwrap();
+        assert!(res1.starts_with("ey"));
+
+        let res2 = gen_token(
+            User {
+                user_id: "user_id".to_owned(),
+                email: "email".to_owned(),
+                password: "password".to_owned(),
+                admin: true,
+                first_name: "first_name".to_owned(),
+                last_name: "last_name".to_owned(),
+                date_of_birth: "date_of_birth".to_owned(),
+                height: 185,
+                weight: 85000,
+                box_name: "box_name".to_owned(),
+                avatar_url: "avatar_url".to_owned(),
+            },
+            "email",
+            true,
+        )
+        .unwrap();
+        assert!(res2.starts_with("ey"));
     }
 }


### PR DESCRIPTION
When registering, I don't want to all the user info to be added at that time, it should be updated in the user profile later on.

This change was done after starting the app development. This makes it much easier to add 'Sign in with Apple' in the future, where I wont get all these fields, since they're custom for this system.