### PR TITLE
feat: health endpoint checks db connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Back-end for the [wodbook-app](https://github.com/egilsster/wodbook-app).
 # Run the server (Add --release for an optimized build)
 λ cargo run
 ...
-[2020-06-29T22:30:49Z DEBUG wodbook_api] Listening on 127.0.0.1:43210
+[2020-06-30T21:54:36Z INFO  wodbook_api::db::connection] Connected to mongodb
+[2020-06-30T21:54:36Z INFO  wodbook_api] Listening on 0.0.0.0:43210
 ```
 
 ## APIs

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -1,18 +1,32 @@
-use crate::errors::AppError;
 use crate::utils::Config;
 use mongodb::Client;
 
 pub struct Connection;
 
 impl Connection {
-    pub async fn get_client(&self) -> Result<Client, AppError> {
+    pub async fn get_client(&self) -> Result<Client, ()> {
         let config = Config::from_env().unwrap();
+        let client = Client::with_uri_str(&config.mongo.uri).await;
+        if client.is_err() {
+            error!(
+                "Error when creating mongodb client: {}",
+                client.unwrap_err().to_string()
+            );
+            std::process::exit(1)
+        }
 
-        Client::with_uri_str(&config.mongo.uri)
-            .await
-            .map_err(|err| {
-                error!("Error connecting to mongo");
-                AppError::Internal(err.to_string())
-            })
+        let client = client.unwrap();
+        let ping_res = client
+            .database("admin")
+            .run_command(doc! {"ping": 1}, None)
+            .await;
+
+        if ping_res.is_ok() {
+            info!("Connected to mongodb");
+        } else {
+            error!("Connection to mongo is not functioning");
+        }
+
+        Ok(client)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate bson;
 
 use crate::db::connection::Connection;
 use crate::utils::mywod::AVATAR_FILE_LOCATION;
@@ -30,8 +32,6 @@ async fn main() -> io::Result<()> {
 
     let config = Config::from_env().unwrap();
     let server_addr = format!("{}:{}", config.host, config.port);
-
-    // TODO(egilsster): Handle when mongo isn't up, with a warning or something
     let mongo_client = Connection.get_client().await.unwrap();
 
     let app = move || {
@@ -49,6 +49,6 @@ async fn main() -> io::Result<()> {
             .service(web::scope("/").configure(routes::index::init_routes))
     };
 
-    debug!("Listening on {}", server_addr);
+    info!("Listening on {}", server_addr);
     HttpServer::new(app).bind(server_addr)?.run().await
 }

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -1,4 +1,4 @@
-use bson::{doc, Document};
+use bson::Document;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,4 +1,4 @@
-use bson::{doc, Document};
+use bson::Document;
 use serde::{Deserialize, Serialize};
 
 // https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006

--- a/src/models/workout.rs
+++ b/src/models/workout.rs
@@ -1,4 +1,4 @@
-use bson::{doc, Document};
+use bson::Document;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 

--- a/src/repositories/movement_repository.rs
+++ b/src/repositories/movement_repository.rs
@@ -5,7 +5,7 @@ use crate::models::movement::{
 };
 use crate::utils::{query_utils, validator, Config};
 
-use bson::{doc, from_bson, Bson};
+use bson::{from_bson, Bson};
 use chrono::Utc;
 use futures::stream::StreamExt;
 use mongodb::options::FindOptions;

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -2,7 +2,7 @@ use crate::errors::AppError;
 use crate::models::user::{Claims, CreateUser, Login, UpdateUser, User};
 use crate::utils::{resources, Config};
 
-use bson::{doc, from_bson, Bson};
+use bson::{from_bson, Bson};
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
 use mongodb::{Client, Collection};

--- a/src/repositories/workout_repository.rs
+++ b/src/repositories/workout_repository.rs
@@ -5,7 +5,7 @@ use crate::models::workout::{
 };
 use crate::utils::{query_utils, validator, Config};
 
-use bson::{doc, from_bson, Bson};
+use bson::{from_bson, Bson};
 use chrono::Utc;
 use futures::stream::StreamExt;
 use mongodb::options::FindOptions;

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -1,13 +1,24 @@
 use crate::errors::AppError;
 use crate::models::response::HealthResponse;
 use crate::utils::api_docs::parse_spec;
+use crate::utils::AppState;
 use actix_web::{get, web, HttpResponse, Responder};
 
 #[get("/health")]
-pub async fn health() -> HttpResponse {
-    HttpResponse::Ok().json(HealthResponse {
-        status: "ok".to_owned(),
-    })
+pub async fn health(state: web::Data<AppState>) -> HttpResponse {
+    let client = state.mongo_client.clone();
+    let ping_res = client
+        .database("admin")
+        .run_command(doc! {"ping": 1}, None)
+        .await;
+    match ping_res {
+        Ok(_) => HttpResponse::Ok().json(HealthResponse {
+            status: "ok".to_owned(),
+        }),
+        Err(_) => HttpResponse::ServiceUnavailable().json(HealthResponse {
+            status: "mongodb not available".to_owned(),
+        }),
+    }
 }
 
 #[get("/openapi")]

--- a/src/utils/query_utils.rs
+++ b/src/utils/query_utils.rs
@@ -1,4 +1,4 @@
-use bson::{doc, Document};
+use bson::Document;
 
 /// Creates a query that gets all documents that have
 /// the given `user_id` as well as public resources.


### PR DESCRIPTION
After deploying the api and trying it from the iOS app, I was getting timeouts after 30s. I checked the logs and it had issues with the mongo connection. Health check continues to serve "ok" despite that.

This ensures the health endpoint returns `200` when mongo is ok and `503` if it isn't connected. I will update the connection string to timeout after a shorter time, 2s is probably fine but I can tune it as I go.