### PR TITLE
build: optimize release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,9 @@ data-encoding = "2.2.1"
 
 [dev-dependencies]
 futures-await-test = "0.3.0"
+
+[profile.release]
+opt-level = 'z'
+lto = true
+codegen-units = 1
+panic = 'abort'

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ./target/release/wodbook-api


### PR DESCRIPTION
5M trimmed off, perf testing pending. This is a good start.

`10M Jul  1 00:25 wodbook-api`

Closes https://github.com/egilsster/wodbook-api/issues/184