### PR TITLE
Omit slashes from root endpoints

### DIFF
--- a/integration_tests/movement.test.ts
+++ b/integration_tests/movement.test.ts
@@ -3,7 +3,7 @@ import * as request from "request-promise-native";
 import * as HttpStatus from "http-status-codes";
 import { createUsers, getMongoClient } from "./common";
 
-describe("/v1/movements/", () => {
+describe("/v1/movements", () => {
   const reqOpts: request.RequestPromiseOptions = {
     json: true,
     resolveWithFullResponse: true, // Get the full response instead of just the body
@@ -64,7 +64,7 @@ describe("/v1/movements/", () => {
   describe("listing movements", () => {
     it("should return 200 OK with a list", async (done) => {
       try {
-        const res1: ManyMovementsResponse = await request.get("/movements/", {
+        const res1: ManyMovementsResponse = await request.get("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -96,7 +96,7 @@ describe("/v1/movements/", () => {
           measurement: "weight",
           public: true,
         };
-        const res0: MovementResponse = await request.post("/movements/", {
+        const res0: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -107,7 +107,7 @@ describe("/v1/movements/", () => {
 
         expect(res0.statusCode).toBe(HttpStatus.CREATED);
 
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -145,7 +145,7 @@ describe("/v1/movements/", () => {
         expect(res2.body).toHaveProperty("measurement", movement.measurement);
         expect(res2.body).toHaveProperty("name", movement.name);
 
-        const res3: ManyMovementsResponse = await request.get("/movements/", {
+        const res3: ManyMovementsResponse = await request.get("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -189,7 +189,7 @@ describe("/v1/movements/", () => {
         };
 
         const res1: MovementResponse = await request.post(
-          "/movements/",
+          "/movements",
           payload
         );
 
@@ -201,7 +201,7 @@ describe("/v1/movements/", () => {
         expect(res1.body).toHaveProperty("name", movement.name);
 
         const res2: MovementResponse = await request.post(
-          "/movements/",
+          "/movements",
           payload
         );
 
@@ -214,7 +214,7 @@ describe("/v1/movements/", () => {
 
     it("should get 422 Unprocessable Entity if an invalid measurement", async (done) => {
       try {
-        const res: MovementResponse = await request.post("/movements/", {
+        const res: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -242,7 +242,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -336,7 +336,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -353,7 +353,7 @@ describe("/v1/movements/", () => {
         const movementId = res1.body.movement_id;
         expect(res1.body).toHaveProperty("name", "Sholder Press");
 
-        const res2: MovementResponse = await request.post("/movements/", {
+        const res2: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -410,7 +410,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -477,7 +477,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -550,7 +550,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -650,7 +650,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -753,7 +753,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -817,7 +817,7 @@ describe("/v1/movements/", () => {
       };
 
       try {
-        const res1: MovementResponse = await request.post("/movements/", {
+        const res1: MovementResponse = await request.post("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -107,7 +107,7 @@ describe("/users/mywod", () => {
 
         // TODO: Check for workout scores
 
-        const res4: ManyMovementsResponse = await request.get("/movements/", {
+        const res4: ManyMovementsResponse = await request.get("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -174,7 +174,7 @@ describe("/users/mywod", () => {
 
         // TODO: Check workout scores
 
-        const res10: ManyMovementsResponse = await request.get("/movements/", {
+        const res10: ManyMovementsResponse = await request.get("/movements", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -92,7 +92,7 @@ describe("/users/mywod", () => {
         expect(userBefore.weight).toEqual(user.weight);
         expect(userBefore.avatar_url).toEqual(user.avatar_url);
 
-        const res2: ManyWorkoutsResponse = await request.get("/workouts/", {
+        const res2: ManyWorkoutsResponse = await request.get("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -159,7 +159,7 @@ describe("/users/mywod", () => {
         expect(userAfter.weight).not.toEqual(user.weight);
         // expect(userAfter.avatar_url).not.toEqual(user.avatar_url);
 
-        const res8: ManyWorkoutsResponse = await request.get("/workouts/", {
+        const res8: ManyWorkoutsResponse = await request.get("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",

--- a/integration_tests/workout.test.ts
+++ b/integration_tests/workout.test.ts
@@ -64,7 +64,7 @@ describe("/v1/workouts", () => {
   describe("listing workouts", () => {
     it("should return 200 OK with a list", async (done) => {
       try {
-        const res1: ManyWorkoutsResponse = await request.get("/workouts/", {
+        const res1: ManyWorkoutsResponse = await request.get("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -98,7 +98,7 @@ describe("/v1/workouts", () => {
           description: "Do some work",
           public: true,
         };
-        const res0: WorkoutResponse = await request.post("/workouts/", {
+        const res0: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -109,7 +109,7 @@ describe("/v1/workouts", () => {
 
         expect(res0.statusCode).toBe(HttpStatus.CREATED);
 
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -148,7 +148,7 @@ describe("/v1/workouts", () => {
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
 
-        const res3: ManyWorkoutsResponse = await request.get("/workouts/", {
+        const res3: ManyWorkoutsResponse = await request.get("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -193,7 +193,7 @@ describe("/v1/workouts", () => {
           body: workout,
         };
 
-        const res1: WorkoutResponse = await request.post("/workouts/", payload);
+        const res1: WorkoutResponse = await request.post("/workouts", payload);
 
         expect(res1.statusCode).toBe(HttpStatus.CREATED);
         expect(res1.body).toHaveProperty("workout_id");
@@ -204,7 +204,7 @@ describe("/v1/workouts", () => {
         expect(res1.body).toHaveProperty("created_at");
         expect(res1.body).toHaveProperty("updated_at");
 
-        const res2: WorkoutResponse = await request.post("/workouts/", payload);
+        const res2: WorkoutResponse = await request.post("/workouts", payload);
 
         expect(res2.statusCode).toBe(HttpStatus.CONFLICT);
         done();
@@ -215,7 +215,7 @@ describe("/v1/workouts", () => {
 
     it("should get 422 Unprocessable Entity if using an invalid measurement", async (done) => {
       try {
-        const res: WorkoutResponse = await request.post("/workouts/", {
+        const res: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -247,7 +247,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -347,7 +347,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -363,7 +363,7 @@ describe("/v1/workouts", () => {
         expect(res1.body).toHaveProperty("description", wod.description);
         expect(res1.body).toHaveProperty("measurement", wod.measurement);
 
-        const res2: WorkoutResponse = await request.post("/workouts/", {
+        const res2: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -424,7 +424,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -492,7 +492,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -570,7 +570,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -675,7 +675,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -784,7 +784,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",
@@ -857,7 +857,7 @@ describe("/v1/workouts", () => {
       };
 
       try {
-        const res1: WorkoutResponse = await request.post("/workouts/", {
+        const res1: WorkoutResponse = await request.post("/workouts", {
           ...reqOpts,
           headers: {
             "Content-Type": "application/json",

--- a/src/routes/movements.rs
+++ b/src/routes/movements.rs
@@ -8,7 +8,7 @@ use crate::repositories::MovementRepository;
 use crate::utils::AppState;
 use actix_web::{delete, get, patch, post, web, HttpResponse, Responder};
 
-#[get("/")]
+#[get("")]
 async fn get_movements(
     state: web::Data<AppState>,
     claims: Claims,
@@ -24,7 +24,7 @@ async fn get_movements(
     result.map(|movements| HttpResponse::Ok().json(ManyMovementsResponse { data: movements }))
 }
 
-#[post("/")]
+#[post("")]
 async fn create_movement(
     state: web::Data<AppState>,
     claims: Claims,

--- a/src/routes/workouts.rs
+++ b/src/routes/workouts.rs
@@ -8,7 +8,7 @@ use crate::repositories::WorkoutRepository;
 use crate::utils::AppState;
 use actix_web::{delete, get, patch, post, web, HttpResponse, Responder};
 
-#[get("/")]
+#[get("")]
 async fn get_workouts(
     state: web::Data<AppState>,
     claims: Claims,
@@ -23,7 +23,7 @@ async fn get_workouts(
     result.map(|workouts| HttpResponse::Ok().json(ManyWorkoutsResponse { data: workouts }))
 }
 
-#[post("/")]
+#[post("")]
 async fn create_workout(
     state: web::Data<AppState>,
     claims: Claims,


### PR DESCRIPTION
Actix needs either one to be specified, don't really want to hack anything together to support both, so I went with no slash on the root path.

Closes https://github.com/egilsster/wodbook-api/issues/189