### PR TITLE
fix: handle invalid mywod file uploads

### DIFF
--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -6,6 +6,7 @@ import { createUsers, getMongoClient } from "./common";
 import users from "./data/users";
 
 const mywodFilePath = `${process.cwd()}/data.mywod`;
+const packageJsonFilePath = `${process.cwd()}/package.json`;
 
 describe("/users/mywod", () => {
   const reqOpts: request.RequestPromiseOptions = {
@@ -190,6 +191,27 @@ describe("/users/mywod", () => {
         expect(movementsAfter.length).toBeGreaterThan(movementsBefore.length);
 
         // TODO: Check movement scores
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it("should get a 500 error if file is not valid", async (done) => {
+      try {
+        // Submit the mywod file for migration
+        const res1: MyWodResponse = await request.post("/users/mywod", {
+          ...reqOpts,
+          headers: {
+            Authorization: `Bearer ${userToken}`,
+          },
+          formData: {
+            file: createReadStream(packageJsonFilePath),
+          },
+        });
+
+        expect(res1.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
 
         done();
       } catch (err) {

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -94,7 +94,7 @@ async fn sync_mywod(
     let deleted = delete_payload_file(written_filename).await?;
     info!("File deleted after handling: {}", deleted);
 
-    let mywod_data = mywod_data.unwrap();
+    let mywod_data = mywod_data?;
 
     let user_updated =
         mywod::save_athlete(user_repo, user_id, user_email, mywod_data.athlete).await?;


### PR DESCRIPTION
The fn already returns `Result<MyWodData, AppError>` so I can use `?` instead, as we should. Added an integration test to check this using `package.json` as the file buffer.

Fixes https://github.com/egilsster/wodbook-api/issues/200