### PR TITLE
refactor: more error handling and refactoring

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
       "env": {
         "NODE_ENV": "test",
         // "MONGO__DB_NAME": "wodbook-api"
-        "MONGO__DB_NAME": "wodbook-test"
+        "MONGO__DB_NAME": "wodbook-test",
+        "RUST_LOG": "wodbook_api=debug,actix_web=debug"
       }
     },
     {

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -160,7 +160,7 @@ describe("/users/mywod", () => {
         expect(userAfter.email).toEqual(user.email);
         expect(userAfter.height).not.toEqual(user.height);
         expect(userAfter.weight).not.toEqual(user.weight);
-        // expect(userAfter.avatar_url).not.toEqual(user.avatar_url);
+        expect(userAfter.avatar_url).not.toEqual(user.avatar_url);
 
         const res8: ManyWorkoutsResponse = await request.get("/workouts", {
           ...reqOpts,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,3 +37,5 @@ impl ResponseError for AppError {
         })
     }
 }
+
+pub type WebResult<T> = Result<T, AppError>;

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -119,6 +119,7 @@ pub struct UpdateMovementScore {
 pub struct MovementScoreResponse {
     pub movement_score_id: String,
     pub movement_id: String,
+    pub user_id: String,
     pub score: String,
     pub sets: u32,
     pub reps: u32,
@@ -129,11 +130,11 @@ pub struct MovementScoreResponse {
 }
 
 impl MovementScoreResponse {
-    pub fn to_doc(&self, user_id: &str) -> Document {
+    pub fn to_doc(&self) -> Document {
         doc! {
             "movement_score_id": self.movement_score_id.to_owned(),
             "movement_id": self.movement_id.to_owned(),
-            "user_id": user_id.to_owned(),
+            "user_id": self.user_id.to_owned(),
             "score": self.score.to_owned(),
             "sets": self.sets.to_owned(),
             "reps": self.reps.to_owned(),

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -1,7 +1,7 @@
 use bson::Document;
 use serde::{Deserialize, Serialize};
-use std::vec::Vec;
 use std::fmt;
+use std::vec::Vec;
 
 // https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006
 fn default_as_false() -> bool {

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -1,6 +1,7 @@
 use bson::Document;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
+use std::fmt;
 
 // https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006
 fn default_as_false() -> bool {
@@ -26,10 +27,10 @@ pub enum MovementMeasurement {
 }
 
 // TODO: Find a nicer way of serializing into strings without the quotes
-impl MovementMeasurement {
-    pub fn to_string(&self) -> String {
-        let string_val = serde_json::to_string(self).unwrap_or("none".to_owned());
-        string_val.trim_matches('"').to_owned()
+impl fmt::Display for MovementMeasurement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let string_val = serde_json::to_string(self).unwrap_or_else(|_| "none".to_owned());
+        write!(f, "{}", string_val.trim_matches('"'))
     }
 }
 
@@ -157,5 +158,19 @@ impl MovementScoreResponse {
             "created_at": self.created_at.to_owned(),
             "updated_at": self.updated_at.to_owned(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_measurement_to_string() {
+        assert_eq!(MovementMeasurement::Weight.to_string(), "weight");
+        assert_eq!(MovementMeasurement::Distance.to_string(), "distance");
+        assert_eq!(MovementMeasurement::Reps.to_string(), "reps");
+        assert_eq!(MovementMeasurement::Height.to_string(), "height");
+        assert_eq!(MovementMeasurement::None.to_string(), "none");
     }
 }

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -1,4 +1,3 @@
-use crate::errors::AppError;
 use bson::Document;
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
@@ -26,6 +25,14 @@ pub enum MovementMeasurement {
     None,
 }
 
+// TODO: Find a nicer way of serializing into strings without the quotes
+impl MovementMeasurement {
+    pub fn to_string(&self) -> String {
+        let string_val = serde_json::to_string(self).unwrap_or("none".to_owned());
+        string_val.trim_matches('"').to_owned()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MovementModel {
     pub movement_id: String,
@@ -38,9 +45,16 @@ pub struct MovementModel {
 }
 
 impl MovementModel {
-    pub fn to_doc(&self) -> Result<Document, AppError> {
-        let as_bson = &bson::to_bson(&self).map_err(|e| AppError::BadRequest(e.to_string()))?;
-        Ok(bson::Bson::as_document(as_bson).unwrap().to_owned())
+    pub fn to_doc(&self) -> Document {
+        doc! {
+            "movement_id": self.movement_id.to_owned(),
+            "user_id": self.user_id.to_owned(),
+            "name": self.name.to_owned(),
+            "measurement": self.measurement.to_string().to_lowercase(),
+            "public": self.public,
+            "created_at": self.created_at.to_owned(),
+            "updated_at": self.updated_at.to_owned(),
+        }
     }
 }
 

--- a/src/models/workout.rs
+++ b/src/models/workout.rs
@@ -1,5 +1,6 @@
 use bson::Document;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::vec::Vec;
 
 // https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006
@@ -27,10 +28,10 @@ pub enum WorkoutMeasurement {
 }
 
 // TODO: Find a nicer way of serializing into strings without the quotes
-impl WorkoutMeasurement {
-    pub fn to_string(&self) -> String {
-        let string_val = serde_json::to_string(self).unwrap_or("none".to_owned());
-        string_val.trim_matches('"').to_owned()
+impl fmt::Display for WorkoutMeasurement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let string_val = serde_json::to_string(self).unwrap_or_else(|_| "none".to_owned());
+        write!(f, "{}", string_val.trim_matches('"'))
     }
 }
 
@@ -155,5 +156,24 @@ impl WorkoutScoreResponse {
             "created_at": self.created_at.to_owned(),
             "updated_at": self.updated_at.to_owned(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_measurement_to_string() {
+        assert_eq!(WorkoutMeasurement::Time.to_string(), "time");
+        assert_eq!(WorkoutMeasurement::Distance.to_string(), "distance");
+        assert_eq!(WorkoutMeasurement::Load.to_string(), "load");
+        assert_eq!(WorkoutMeasurement::Repetitions.to_string(), "repetitions");
+        assert_eq!(WorkoutMeasurement::Rounds.to_string(), "rounds");
+        assert_eq!(WorkoutMeasurement::TimedRounds.to_string(), "timed_rounds");
+        assert_eq!(WorkoutMeasurement::Tabata.to_string(), "tabata");
+        assert_eq!(WorkoutMeasurement::Total.to_string(), "total");
+        assert_eq!(WorkoutMeasurement::Unknown.to_string(), "unknown");
+        assert_eq!(WorkoutMeasurement::None.to_string(), "none");
     }
 }

--- a/src/repositories/movement_repository.rs
+++ b/src/repositories/movement_repository.rs
@@ -148,7 +148,7 @@ impl MovementRepository {
             updated_at: now.to_owned(),
         };
 
-        coll.insert_one(movement.to_doc()?, None)
+        coll.insert_one(movement.to_doc(), None)
             .await
             .map_err(|err| AppError::Internal(err.to_string()))?;
 
@@ -198,13 +198,9 @@ impl MovementRepository {
         };
 
         let coll = self.get_movement_collection();
-        coll.update_one(
-            doc! { "movement_id": movement_id },
-            movement.to_doc()?,
-            None,
-        )
-        .await
-        .map_err(|_| AppError::Internal("Could not update movement".to_owned()))?;
+        coll.update_one(doc! { "movement_id": movement_id }, movement.to_doc(), None)
+            .await
+            .map_err(|_| AppError::Internal("Could not update movement".to_owned()))?;
 
         let model = self
             .find_movement_by_id(user_id, movement_id)

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -65,12 +65,14 @@ impl UserRepository {
         user.box_name = user_update.box_name.unwrap_or(user.box_name);
         user.avatar_url = user_update.avatar_url.unwrap_or(user.avatar_url);
 
-        let user_doc = user.to_doc();
-
         let coll = self.get_collection();
-        coll.update_one(doc! { "user_id": user.user_id }, user_doc, None)
-            .await
-            .map_err(|_| AppError::Internal("Could not update user".to_owned()))?;
+        coll.update_one(
+            doc! { "user_id": user.user_id.to_owned() },
+            user.to_doc(),
+            None,
+        )
+        .await
+        .map_err(|_| AppError::Internal("Could not update user".to_owned()))?;
 
         self.find_user_with_email(email).await
     }

--- a/src/repositories/workout_repository.rs
+++ b/src/repositories/workout_repository.rs
@@ -1,4 +1,4 @@
-use crate::errors::AppError;
+use crate::errors::{AppError, WebResult};
 use crate::models::workout::{
     CreateWorkout, CreateWorkoutScore, UpdateWorkout, UpdateWorkoutScore, WorkoutModel,
     WorkoutScoreResponse,
@@ -38,7 +38,7 @@ impl WorkoutRepository {
         &self,
         user_id: &str,
         name: &str,
-    ) -> Result<Option<WorkoutModel>, AppError> {
+    ) -> WebResult<Option<WorkoutModel>> {
         let query = query_utils::for_one(doc! {"name": name }, user_id);
         let cursor = self
             .get_workout_collection()
@@ -60,7 +60,7 @@ impl WorkoutRepository {
         &self,
         user_id: &str,
         workout_id: &str,
-    ) -> Result<Option<WorkoutModel>, AppError> {
+    ) -> WebResult<Option<WorkoutModel>> {
         let query = query_utils::for_one(doc! {"workout_id": workout_id }, user_id);
         let cursor = self
             .get_workout_collection()
@@ -78,7 +78,7 @@ impl WorkoutRepository {
         }
     }
 
-    pub async fn get_workouts(&self, user_id: &str) -> Result<Vec<WorkoutModel>, AppError> {
+    pub async fn get_workouts(&self, user_id: &str) -> WebResult<Vec<WorkoutModel>> {
         let query = query_utils::for_many(user_id);
         let find_options = FindOptions::builder().sort(doc! { "name": 1 }).build();
         let mut cursor = self
@@ -94,10 +94,10 @@ impl WorkoutRepository {
                 let workout = from_bson::<WorkoutModel>(Bson::Document(result));
                 match workout {
                     Ok(result) => vec.push(result),
-                    Err(e) => println!("Error parsing workout: {:?}", e),
+                    Err(e) => warn!("Error parsing workout: {:?}", e),
                 }
             } else {
-                println!("Error reading workout: {:?}", result.unwrap_err())
+                warn!("Error reading workout: {:?}", result.unwrap_err())
             }
         }
 
@@ -108,7 +108,7 @@ impl WorkoutRepository {
         &self,
         user_id: &str,
         workout_id: &str,
-    ) -> Result<WorkoutModel, AppError> {
+    ) -> WebResult<WorkoutModel> {
         let workout = self.find_workout_by_id(user_id, workout_id).await?;
 
         match workout {
@@ -123,7 +123,7 @@ impl WorkoutRepository {
         &self,
         user_id: &str,
         workout: CreateWorkout,
-    ) -> Result<WorkoutModel, AppError> {
+    ) -> WebResult<WorkoutModel> {
         let workout_name = workout.name.as_ref();
         let existing_workout = self.find_workout_by_name(user_id, workout_name).await?;
 
@@ -164,7 +164,7 @@ impl WorkoutRepository {
         user_id: &str,
         workout_id: &str,
         workout_update: UpdateWorkout,
-    ) -> Result<WorkoutModel, AppError> {
+    ) -> WebResult<WorkoutModel> {
         let existing_workout = self.find_workout_by_id(user_id, workout_id).await?;
 
         if existing_workout.is_none() {
@@ -209,7 +209,7 @@ impl WorkoutRepository {
         Ok(model)
     }
 
-    pub async fn delete_workout(&self, user_id: &str, workout_id: &str) -> Result<(), AppError> {
+    pub async fn delete_workout(&self, user_id: &str, workout_id: &str) -> WebResult<()> {
         let workout = self.find_workout_by_id(user_id, workout_id).await?;
 
         if workout.is_none() {
@@ -231,22 +231,22 @@ impl WorkoutRepository {
         user_id: &str,
         workout_id: &str,
         workout_score: CreateWorkoutScore,
-    ) -> Result<WorkoutScoreResponse, AppError> {
+    ) -> WebResult<WorkoutScoreResponse> {
         let coll = self.get_score_collection();
         let id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
-        let workout_score_doc = doc! {
-            "workout_score_id": id.to_owned(),
-            "user_id": user_id.to_owned(),
-            "workout_id": workout_id.to_owned(),
-            "score": workout_score.score,
-            "rx": workout_score.rx,
-            "notes": workout_score.notes,
-            "created_at": workout_score.created_at.unwrap_or_else(|| now.to_owned()),
-            "updated_at": now.to_owned(),
+        let workout_score = WorkoutScoreResponse {
+            workout_score_id: id.to_owned(),
+            workout_id: workout_id.to_owned(),
+            score: workout_score.score,
+            rx: workout_score.rx,
+            notes: workout_score.notes,
+            // This is for mywod items, as they have their own created at date which prefer to keep
+            created_at: workout_score.created_at.unwrap_or_else(|| now.to_owned()),
+            updated_at: now.to_owned(),
         };
 
-        coll.insert_one(workout_score_doc, None)
+        coll.insert_one(workout_score.to_doc(user_id), None)
             .await
             .map_err(|err| AppError::Internal(err.to_string()))?;
 
@@ -257,7 +257,7 @@ impl WorkoutRepository {
         &self,
         user_id: &str,
         workout_id: &str,
-    ) -> Result<Vec<WorkoutScoreResponse>, AppError> {
+    ) -> WebResult<Vec<WorkoutScoreResponse>> {
         let query = query_utils::for_many_with_filter(
             doc! { "user_id": user_id, "workout_id": workout_id },
             user_id,
@@ -279,10 +279,10 @@ impl WorkoutRepository {
                     let workout_score = from_bson::<WorkoutScoreResponse>(Bson::Document(document));
                     match workout_score {
                         Ok(result) => vec.push(result),
-                        Err(e) => println!("Error parsing workout: {:?}", e),
+                        Err(e) => warn!("Error parsing workout: {:?}", e),
                     }
                 }
-                Err(e) => println!("Error reading workout: {:?}", e),
+                Err(e) => warn!("Error reading workout: {:?}", e),
             }
         }
 
@@ -294,7 +294,7 @@ impl WorkoutRepository {
         user_id: &str,
         workout_id: &str,
         workout_score_id: &str,
-    ) -> Result<WorkoutScoreResponse, AppError> {
+    ) -> WebResult<WorkoutScoreResponse> {
         let query = query_utils::for_one(
             doc! { "workout_id":  workout_id, "workout_score_id": workout_score_id },
             user_id,
@@ -321,43 +321,31 @@ impl WorkoutRepository {
         workout_id: &str,
         workout_score_id: &str,
         new_score: UpdateWorkoutScore,
-    ) -> Result<WorkoutScoreResponse, AppError> {
+    ) -> WebResult<WorkoutScoreResponse> {
         let mut score = self
             .get_workout_score_by_id(user_id, workout_id, workout_score_id)
             .await?;
 
-        let now = Utc::now().to_rfc2822();
-
         score.score = new_score.score.unwrap_or(score.score);
         score.rx = new_score.rx.unwrap_or(score.rx);
         score.notes = new_score.notes.unwrap_or(score.notes);
-        score.updated_at = now;
-
-        let workout_doc = score.to_doc(user_id);
+        score.updated_at = Utc::now().to_rfc3339();
 
         let query = query_utils::for_one(doc! { "workout_score_id": workout_score_id }, user_id);
-        let update_result = self
+        let _ = self
             .get_score_collection()
-            .update_one(query, workout_doc, None)
-            .await;
-
-        if update_result.is_err() {
-            return Err(AppError::Internal(
-                "Something went wrong when updating the score.".to_owned(),
-            ));
-        }
+            .update_one(query, score.to_doc(user_id), None)
+            .await
+            .map_err(|_| {
+                AppError::Internal("Something went wrong when updating the score.".to_owned())
+            })?;
 
         let res = self
             .get_workout_score_by_id(user_id, workout_id, workout_score_id)
-            .await;
+            .await
+            .map_err(|_| AppError::Internal("New score not found after inserting".to_owned()))?;
 
-        if res.is_err() {
-            return Err(AppError::Internal(
-                "New score not found after inserting".to_owned(),
-            ));
-        }
-
-        res
+        Ok(res)
     }
 
     pub async fn delete_workout_score_by_id(
@@ -365,22 +353,22 @@ impl WorkoutRepository {
         user_id: &str,
         workout_id: &str,
         workout_score_id: &str,
-    ) -> Result<(), AppError> {
+    ) -> WebResult<()> {
         // Ensure the score exists for the user
         self.get_workout_score_by_id(user_id, workout_id, workout_score_id)
             .await?;
 
         let query = query_utils::for_one(doc! { "workout_score_id": workout_score_id }, user_id);
-        let delete_result = self.get_score_collection().delete_one(query, None).await;
-
-        if let Err(delete_result) = delete_result {
-            return Err(AppError::Internal(delete_result.to_string()));
-        }
+        let _ = self
+            .get_score_collection()
+            .delete_one(query, None)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
 
         Ok(())
     }
 
-    async fn delete_workout_scores(&self, user_id: &str, workout_id: &str) -> Result<(), AppError> {
+    async fn delete_workout_scores(&self, user_id: &str, workout_id: &str) -> WebResult<()> {
         let query = query_utils::for_many_with_filter(doc! { "workout_id": workout_id }, user_id);
         self.get_score_collection()
             .delete_many(query, None)

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -1,4 +1,4 @@
-use crate::errors::AppError;
+use crate::errors::WebResult;
 use crate::models::response::HealthResponse;
 use crate::utils::api_docs::parse_spec;
 use crate::utils::AppState;
@@ -22,7 +22,7 @@ pub async fn health(state: web::Data<AppState>) -> HttpResponse {
 }
 
 #[get("/openapi")]
-pub async fn api_docs() -> Result<impl Responder, AppError> {
+pub async fn api_docs() -> WebResult<impl Responder> {
     parse_spec().map(|result| HttpResponse::Ok().json(result))
 }
 

--- a/src/utils/api_docs.rs
+++ b/src/utils/api_docs.rs
@@ -1,8 +1,8 @@
-use crate::errors::AppError;
+use crate::errors::{AppError, WebResult};
 use oas3::{from_path, to_json, Spec};
 use serde_json::from_str;
 
-pub fn parse_spec() -> Result<Spec, AppError> {
+pub fn parse_spec() -> WebResult<Spec> {
     let oas_spec = from_path("api-docs.yml").map_err(|err| AppError::Internal(err.to_string()))?;
     let json_string = to_json(&oas_spec).map_err(|err| AppError::Internal(err.to_string()))?;
     let docs: Spec = from_str(&json_string).map_err(|err| AppError::Internal(err.to_string()))?;

--- a/src/utils/mywod.rs
+++ b/src/utils/mywod.rs
@@ -1,4 +1,4 @@
-use crate::errors::AppError;
+use crate::errors::{AppError, WebResult};
 use crate::models::movement::{CreateMovementScore, MovementMeasurement};
 use crate::models::mywod::{Athlete, CustomWOD, Movement, MovementSession, MyWOD, MyWodData};
 use crate::models::workout::{CreateWorkoutScore, WorkoutMeasurement};
@@ -15,7 +15,7 @@ pub const AVATAR_FILE_LOCATION: &str = "./static/avatars";
 
 /// Writes the avatar blob to an image in a static directory and returns
 /// an API path to that image.
-pub fn save_avatar(user_id: &str, avatar: Vec<u8>) -> Result<String, AppError> {
+pub fn save_avatar(user_id: &str, avatar: Vec<u8>) -> WebResult<String> {
     let filename = format!("{}.png", user_id);
     let filepath = format!("{}/{}", AVATAR_FILE_LOCATION, filename);
 
@@ -30,7 +30,7 @@ pub fn save_avatar(user_id: &str, avatar: Vec<u8>) -> Result<String, AppError> {
 
 /// Function to write the multiform upload from the user, this file gets
 /// handled and all data is attempted to be added for the user.
-pub async fn write_payload_to_file(mut payload: Multipart) -> Result<String, AppError> {
+pub async fn write_payload_to_file(mut payload: Multipart) -> WebResult<String> {
     let id = uuid::Uuid::new_v4().to_string();
     let filepath = format!("./tmp/{}", id);
 
@@ -53,7 +53,7 @@ pub async fn write_payload_to_file(mut payload: Multipart) -> Result<String, App
 
 /// Function that cleans up the myWOD file from the file system after it has been
 /// handled and all data has been added for the user.
-pub async fn delete_payload_file(filename: String) -> Result<bool, AppError> {
+pub async fn delete_payload_file(filename: String) -> WebResult<bool> {
     if Path::new(&filename).exists() {
         fs::remove_file(filename)
             .map_err(|_| AppError::Internal("Could not delete file".to_owned()))?;
@@ -64,7 +64,7 @@ pub async fn delete_payload_file(filename: String) -> Result<bool, AppError> {
 
 /// Function that reads the mywod database file and returns the contents in
 /// a parsed way which is then added to the user profile.
-pub async fn read_contents(filename: &str) -> Result<MyWodData, AppError> {
+pub async fn read_contents(filename: &str) -> WebResult<MyWodData> {
     let db = Connection::open(filename)
         .map_err(|_| AppError::Internal("Error opening connection".to_owned()))?;
 
@@ -333,7 +333,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_read_contents() -> Result<(), AppError> {
+    async fn test_read_contents() -> WebResult<()> {
         let res = read_contents("data.mywod").await;
         assert!(res.is_ok());
         Ok(())
@@ -395,7 +395,7 @@ mod tests {
     #[test]
     fn test_parse_short_date() {
         let res = parse_short_date("1991-12-06");
-        assert_eq!(res.unwrap().to_string(), "1991-12-06T00:00:00+00:00");
+        assert_eq!(res.unwrap(), "1991-12-06T00:00:00+00:00");
     }
 
     #[test]


### PR DESCRIPTION
This PR does the following:

- Improved error handling
- Cleaned up Result return types
- Cleaned up some logic with `match`
- Used logger `println` was used
- Changed the `bson` parsing to pick explicitly what I want for the document