### PR TITLE
feat: consolidate score types

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -916,8 +916,6 @@ components:
           type: number
         reps:
           type: number
-        distance:
-          type: string
         notes:
           type: string
           description: Any notes to mention for this score (after a wod, etc.).

--- a/integration_tests/mywod.test.ts
+++ b/integration_tests/mywod.test.ts
@@ -190,6 +190,15 @@ describe("/users/mywod", () => {
         const movementsAfter = res10.body.data;
         expect(movementsAfter.length).toBeGreaterThan(movementsBefore.length);
 
+        // Find 1000m rowing and 21.1km rowing
+        const defaultRow: any = movementsAfter.find((movement) => movement.name === 'Rowing');
+        const shortRow: any = movementsAfter.find((movement) => movement.name === '1000m Rowing');
+        const longRow: any = movementsAfter.find((movement) => movement.name === '21.1km Rowing');
+
+        expect(defaultRow).toBeUndefined();
+        expect(shortRow.measurement).toEqual('time');
+        expect(longRow.measurement).toEqual('time');
+
         // TODO: Check movement scores
 
         done();

--- a/integration_tests/types/movement.d.ts
+++ b/integration_tests/types/movement.d.ts
@@ -29,7 +29,6 @@ type MovementScoreData = {
   score: string;
   reps: number;
   sets: number;
-  distance: string;
   notes: string;
   created_at: string;
   updated_at: string;

--- a/mongo.seed
+++ b/mongo.seed
@@ -21,7 +21,7 @@ db.users.insertMany([
     date_of_birth: "1991-12-06",
     admin: true,
     height: NumberInt(189),
-    weight: NumberInt(920000),
+    weight: NumberInt(92000),
     box_name: "none",
     avatar_url: "",
   },

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -19,8 +19,8 @@ fn default_as_one() -> u32 {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum MovementMeasurement {
+    Time, // fka Distance
     Weight,
-    Distance,
     Reps,
     Height,
     None,
@@ -115,8 +115,6 @@ pub struct CreateMovementScore {
     #[serde(default = "default_as_one")]
     pub reps: u32,
     #[serde(default = "default_as_empty_string")]
-    pub distance: String,
-    #[serde(default = "default_as_empty_string")]
     pub notes: String,
     pub created_at: Option<String>,
 }
@@ -126,7 +124,6 @@ pub struct UpdateMovementScore {
     pub score: Option<String>,
     pub sets: Option<u32>,
     pub reps: Option<u32>,
-    pub distance: Option<String>,
     pub notes: Option<String>,
 }
 
@@ -138,7 +135,6 @@ pub struct MovementScoreResponse {
     pub score: String,
     pub sets: u32,
     pub reps: u32,
-    pub distance: String,
     pub notes: String,
     pub created_at: String,
     pub updated_at: String,
@@ -153,7 +149,6 @@ impl MovementScoreResponse {
             "score": self.score.to_owned(),
             "sets": self.sets.to_owned(),
             "reps": self.reps.to_owned(),
-            "distance": self.distance.to_owned(),
             "notes": self.notes.to_owned(),
             "created_at": self.created_at.to_owned(),
             "updated_at": self.updated_at.to_owned(),
@@ -167,8 +162,8 @@ mod tests {
 
     #[test]
     fn test_measurement_to_string() {
+        assert_eq!(MovementMeasurement::Time.to_string(), "time");
         assert_eq!(MovementMeasurement::Weight.to_string(), "weight");
-        assert_eq!(MovementMeasurement::Distance.to_string(), "distance");
         assert_eq!(MovementMeasurement::Reps.to_string(), "reps");
         assert_eq!(MovementMeasurement::Height.to_string(), "height");
         assert_eq!(MovementMeasurement::None.to_string(), "none");

--- a/src/repositories/movement_repository.rs
+++ b/src/repositories/movement_repository.rs
@@ -243,7 +243,6 @@ impl MovementRepository {
             score: movement_score.score,
             sets: movement_score.sets,
             reps: movement_score.reps,
-            distance: movement_score.distance,
             notes: movement_score.notes,
             // This is for mywod items, as they have their own created at date which prefer to keep
             created_at: movement_score.created_at.unwrap_or_else(|| now.to_owned()),
@@ -345,7 +344,6 @@ impl MovementRepository {
         score.reps = new_score.reps.unwrap_or(score.reps);
         score.sets = new_score.sets.unwrap_or(score.sets);
         score.notes = new_score.notes.unwrap_or(score.notes);
-        score.distance = new_score.distance.unwrap_or(score.distance);
         score.updated_at = Utc::now().to_rfc3339();
 
         let query = query_utils::for_one(doc! { "movement_score_id": movement_score_id }, user_id);


### PR DESCRIPTION
Closes https://github.com/egilsster/wodbook-api/issues/207

When retrieving data from the mywod backup, I add the distance data to the distance measured workouts so I have them split up, that way I don't have to pollute the other score types with `distance`. This PR removes the `distance` field from all score models