### PR TITLE
ci: run tests with 1.45.2

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -27,7 +27,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           components: clippy
           override: true
       - name: Run cargo clippy
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       - name: build app
         run: cargo build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.2
           override: true
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -27,7 +27,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.2
           components: clippy
           override: true
       - name: Run cargo clippy
@@ -59,7 +59,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.2
           override: true
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.2
           override: true
       - name: build app
         run: cargo build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.2
           override: true
       - name: build app
         run: cargo build


### PR DESCRIPTION
Rustc is having issues compiling this on `1.46.0` and later (including `beta` and `nightly`) so going to try downgrading to `1.45.2` which is working well. I tried narrowing down which package is causing the slowdown but didnt spent too long on it and got nowhere with the few I tried.

_Might_ be related to this issue https://github.com/rust-lang/rust/issues/54540