### PR TITLE
ci: run tests on stable

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       - name: build app
         run: cargo build


### PR DESCRIPTION
Checking if it works properly on `1.47.0`