### PR TITLE
feat: endpoint for all user scores

### DIFF
--- a/integration_tests/types/movement.d.ts
+++ b/integration_tests/types/movement.d.ts
@@ -23,7 +23,7 @@ declare type ManyMovementsResponse = {
   body: ManyMovementsData;
 };
 
-type MovementScoreData = {
+declare type MovementScoreData = {
   movement_id: string;
   movement_score_id: string;
   score: string;

--- a/integration_tests/types/user.d.ts
+++ b/integration_tests/types/user.d.ts
@@ -30,3 +30,13 @@ declare type UserResponse = {
   statusCode: number;
   body: UserData;
 };
+
+type UserScores = {
+  movement_scores: MovementScoreData[];
+  workout_scores: WorkoutScoreData[];
+};
+
+declare type UserScoreResponse = {
+  statusCode: number;
+  body: UserScores;
+};

--- a/integration_tests/types/workout.d.ts
+++ b/integration_tests/types/workout.d.ts
@@ -24,7 +24,7 @@ declare type ManyWorkoutsResponse = {
   body: ManyWorkoutsData;
 };
 
-type WorkoutScoreData = {
+declare type WorkoutScoreData = {
   workout_id: string;
   workout_score_id: string;
   score: string;

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -1,3 +1,4 @@
+use crate::models::{movement::MovementScoreResponse, workout::WorkoutScoreResponse};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -21,4 +22,10 @@ pub struct UserResponse {
     pub weight: i32,
     pub box_name: String,
     pub avatar_url: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct UserScoreResponse {
+    pub movement_scores: Vec<MovementScoreResponse>,
+    pub workout_scores: Vec<WorkoutScoreResponse>,
 }

--- a/src/repositories/movement_repository.rs
+++ b/src/repositories/movement_repository.rs
@@ -229,18 +229,11 @@ impl MovementRepository {
             .await
     }
 
-    pub async fn get_movement_scores(
+    pub async fn get_movement_scores_with_query(
         &self,
-        user_id: &str,
-        movement_id: &str,
+        query: bson::Document,
+        find_options: FindOptions,
     ) -> WebResult<Vec<MovementScoreResponse>> {
-        let query = query_utils::for_many_with_filter(
-            doc! { "user_id": user_id, "movement_id": movement_id },
-            user_id,
-        );
-        let find_options = FindOptions::builder()
-            .sort(doc! { "created_at": 1 })
-            .build();
         let mut cursor = self
             .get_score_collection()
             .find(query, find_options)
@@ -264,6 +257,36 @@ impl MovementRepository {
         }
 
         Ok(vec)
+    }
+
+    pub async fn get_movement_scores_for_user(
+        &self,
+        user_id: &str,
+    ) -> WebResult<Vec<MovementScoreResponse>> {
+        let query = query_utils::for_many_with_filter(doc! { "user_id": user_id }, user_id);
+        let find_options: FindOptions = FindOptions::builder()
+            .sort(doc! { "created_at": 1 })
+            .build();
+
+        self.get_movement_scores_with_query(query, find_options)
+            .await
+    }
+
+    pub async fn get_movement_scores_for_movement(
+        &self,
+        user_id: &str,
+        movement_id: &str,
+    ) -> WebResult<Vec<MovementScoreResponse>> {
+        let query = query_utils::for_many_with_filter(
+            doc! { "user_id": user_id, "movement_id": movement_id },
+            user_id,
+        );
+        let find_options = FindOptions::builder()
+            .sort(doc! { "created_at": 1 })
+            .build();
+
+        self.get_movement_scores_with_query(query, find_options)
+            .await
     }
 
     pub async fn get_movement_score_by_id(

--- a/src/repositories/workout_repository.rs
+++ b/src/repositories/workout_repository.rs
@@ -236,18 +236,11 @@ impl WorkoutRepository {
         self.get_workout_score_by_id(user_id, workout_id, &id).await
     }
 
-    pub async fn get_workout_scores(
+    pub async fn get_workout_scores_with_query(
         &self,
-        user_id: &str,
-        workout_id: &str,
+        query: bson::Document,
+        find_options: FindOptions,
     ) -> WebResult<Vec<WorkoutScoreResponse>> {
-        let query = query_utils::for_many_with_filter(
-            doc! { "user_id": user_id, "workout_id": workout_id },
-            user_id,
-        );
-        let find_options = FindOptions::builder()
-            .sort(doc! { "created_at": 1 })
-            .build();
         let mut cursor = self
             .get_score_collection()
             .find(query, find_options)
@@ -270,6 +263,36 @@ impl WorkoutRepository {
         }
 
         Ok(vec)
+    }
+
+    pub async fn get_workout_scores_for_user(
+        &self,
+        user_id: &str,
+    ) -> WebResult<Vec<WorkoutScoreResponse>> {
+        let query = query_utils::for_many_with_filter(doc! { "user_id": user_id }, user_id);
+        let find_options: FindOptions = FindOptions::builder()
+            .sort(doc! { "created_at": 1 })
+            .build();
+
+        self.get_workout_scores_with_query(query, find_options)
+            .await
+    }
+
+    pub async fn get_workout_scores_for_workout(
+        &self,
+        user_id: &str,
+        workout_id: &str,
+    ) -> WebResult<Vec<WorkoutScoreResponse>> {
+        let query = query_utils::for_many_with_filter(
+            doc! { "user_id": user_id, "workout_id": workout_id },
+            user_id,
+        );
+        let find_options = FindOptions::builder()
+            .sort(doc! { "created_at": 1 })
+            .build();
+
+        self.get_workout_scores_with_query(query, find_options)
+            .await
     }
 
     pub async fn get_workout_score_by_id(

--- a/src/routes/movements.rs
+++ b/src/routes/movements.rs
@@ -94,7 +94,7 @@ async fn get_movement_by_id(
         .get_movement_by_id(user_id, &movement_id)
         .await;
     let scores_result = movement_repo
-        .get_movement_scores(user_id, &movement_id)
+        .get_movement_scores_for_movement(user_id, &movement_id)
         .await;
 
     movement_result.map(|movement| {

--- a/src/routes/workouts.rs
+++ b/src/routes/workouts.rs
@@ -91,7 +91,9 @@ async fn get_workout_by_id(
 
     let user_id = claims.user_id.as_ref();
     let workout_result = workout_repo.get_workout_by_id(user_id, &workout_id).await;
-    let scores_result = workout_repo.get_workout_scores(user_id, &workout_id).await;
+    let scores_result = workout_repo
+        .get_workout_scores_for_workout(user_id, &workout_id)
+        .await;
 
     workout_result.map(|workout| {
         scores_result


### PR DESCRIPTION
This PR adds an endpoint under the user route to retrieve all the scores that have been logged.

Example:

```json
{
    "movement_scores": [],
    "workout_scores": [
        {
            "workout_score_id": "9732b3a5-ac62-4db1-bd2f-b1abdb2a2280",
            "workout_id": "a3c31ccb-cba2-4a44-b3db-1f04ea8deaf5",
            "user_id": "be0718e7-87f2-43bf-90be-9a066e155e6b",
            "score": "3:00",
            "rx": true,
            "notes": "",
            "created_at": "2020-10-13T13:44:30.999897+00:00",
            "updated_at": "2020-10-13T13:44:30.999897+00:00"
        }
    ]
}
```

Closes https://github.com/egilsster/wodbook-api/issues/206