### PR TITLE
ci: use rust 1.48.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: 1.48.0
           override: true
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: 1.48.0
           override: true
       - name: build app
         run: cargo build


### PR DESCRIPTION
This new release fixes the async compilation issue that Actix is affected by so it should build now.