### PR TITLE
refactor: use floats for scores instead of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "log",
  "mongodb",
  "oas3",
+ "regex",
  "ring",
  "rusqlite",
  "serde 1.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ oas3 = "0.2.1"
 rusqlite = { version = "0.24.2", features = ["bundled", "blob"] }
 ring = "0.16.19"
 data-encoding = "2.3.1"
+regex = "1"
 
 [dev-dependencies]
 futures-await-test = "0.3.0"

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -840,7 +840,7 @@ components:
           readOnly: true
           description: The workout this score belongs to.
         score:
-          type: string
+          type: number
         measurement:
           type: string
         rx:
@@ -913,7 +913,7 @@ components:
           readOnly: true
           description: The movement this score belongs to.
         score:
-          type: string
+          type: number
         measurement:
           type: string
         sets:

--- a/integration_tests/movement.test.ts
+++ b/integration_tests/movement.test.ts
@@ -432,7 +432,7 @@ describe("/v1/movements", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "100kg",
+              score: 100,
             },
           }
         );
@@ -536,7 +536,7 @@ describe("/v1/movements", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "200kg",
+              score: 200,
               measurement: "weight",
             },
           }
@@ -545,7 +545,7 @@ describe("/v1/movements", () => {
         expect(res2.statusCode).toBe(HttpStatus.CREATED);
         expect(res2.body).toHaveProperty("movement_score_id");
         expect(res2.body).toHaveProperty("movement_id", movementId);
-        expect(res2.body).toHaveProperty("score", "200kg");
+        expect(res2.body).toHaveProperty("score", 200);
         expect(res2.body).toHaveProperty("measurement", "weight");
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
@@ -610,7 +610,7 @@ describe("/v1/movements", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "200kg",
+              score: 200,
             },
           }
         );
@@ -618,7 +618,7 @@ describe("/v1/movements", () => {
         expect(res2.statusCode).toBe(HttpStatus.CREATED);
         expect(res2.body).toHaveProperty("movement_score_id");
         expect(res2.body).toHaveProperty("movement_id", movementId);
-        expect(res2.body).toHaveProperty("score", "200kg");
+        expect(res2.body).toHaveProperty("score", 200);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
 
@@ -652,7 +652,7 @@ describe("/v1/movements", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "205kg",
+              score: 205,
               measurement: "weight",
               notes: "Jättebra!",
             },
@@ -662,7 +662,7 @@ describe("/v1/movements", () => {
         expect(res4.statusCode).toBe(HttpStatus.OK);
         expect(res4.body).toHaveProperty("movement_score_id");
         expect(res4.body).toHaveProperty("movement_id", movementId);
-        expect(res4.body).toHaveProperty("score", "205kg");
+        expect(res4.body).toHaveProperty("score", 205);
         expect(res4.body).toHaveProperty("notes", "Jättebra!");
         expect(res4.body).toHaveProperty("created_at");
         expect(res4.body).toHaveProperty("updated_at");
@@ -710,7 +710,7 @@ describe("/v1/movements", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "200kg",
+              score: 200,
             },
           }
         );
@@ -718,7 +718,7 @@ describe("/v1/movements", () => {
         expect(res2.statusCode).toBe(HttpStatus.CREATED);
         expect(res2.body).toHaveProperty("movement_score_id");
         expect(res2.body).toHaveProperty("movement_id", movementId);
-        expect(res2.body).toHaveProperty("score", "200kg");
+        expect(res2.body).toHaveProperty("score", 200);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
 

--- a/integration_tests/user.test.ts
+++ b/integration_tests/user.test.ts
@@ -434,7 +434,7 @@ describe("/users", () => {
               Authorization: `Bearer ${token}`,
             },
             body: {
-              score: "200kg",
+              score: 200,
               measurement: "weight",
             },
           }
@@ -464,7 +464,7 @@ describe("/users", () => {
               Authorization: `Bearer ${token}`,
             },
             body: {
-              score: "4:20",
+              score: 260,
               rx: true,
             },
           }
@@ -481,7 +481,7 @@ describe("/users", () => {
               Authorization: `Bearer ${token}`,
             },
             body: {
-              score: "4:19",
+              score: 260,
               rx: true,
             },
           }

--- a/integration_tests/workout.test.ts
+++ b/integration_tests/workout.test.ts
@@ -446,7 +446,7 @@ describe("/v1/workouts", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "4:20",
+              score: 260,
               rx: true,
             },
           }
@@ -555,7 +555,7 @@ describe("/v1/workouts", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "4:20",
+              score: 260,
               rx: true,
             },
           }
@@ -565,7 +565,7 @@ describe("/v1/workouts", () => {
         expect(res2.body).toHaveProperty("workout_id", workoutId);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("score", "4:20");
+        expect(res2.body).toHaveProperty("score", 260); // 4:20 in seconds
         expect(res2.body).toHaveProperty("measurement", "time");
         expect(res2.body).toHaveProperty("rx", true);
 
@@ -634,7 +634,7 @@ describe("/v1/workouts", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "4:20",
+              score: 260,
               rx: false,
             },
           }
@@ -644,7 +644,7 @@ describe("/v1/workouts", () => {
         expect(res2.body).toHaveProperty("workout_id", workoutId);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("score", "4:20");
+        expect(res2.body).toHaveProperty("score", 260);
         expect(res2.body).toHaveProperty("rx", false);
 
         const res3: WorkoutResponse = await request.get(
@@ -664,7 +664,7 @@ describe("/v1/workouts", () => {
         expect(res3.body.scores[0]).toHaveProperty("workout_id", workoutId);
         expect(res3.body.scores[0]).toHaveProperty("created_at");
         expect(res3.body.scores[0]).toHaveProperty("updated_at");
-        expect(res3.body.scores[0]).toHaveProperty("score", "4:20");
+        expect(res3.body.scores[0]).toHaveProperty("score", 260);
         expect(res3.body.scores[0]).toHaveProperty("rx", false);
 
         const workoutScore = res3.body.scores[0];
@@ -678,7 +678,7 @@ describe("/v1/workouts", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "4:10",
+              score: 250,
               rx: true,
               notes: "Deadly!",
             },
@@ -689,7 +689,7 @@ describe("/v1/workouts", () => {
         expect(res4.body).toHaveProperty("workout_id", workoutId);
         expect(res4.body).toHaveProperty("created_at");
         expect(res4.body).toHaveProperty("updated_at");
-        expect(res4.body).toHaveProperty("score", "4:10");
+        expect(res4.body).toHaveProperty("score", 250);
         expect(res4.body).toHaveProperty("rx", true);
         expect(res4.body).toHaveProperty("notes", "Deadly!");
 
@@ -739,7 +739,7 @@ describe("/v1/workouts", () => {
               Authorization: `Bearer ${userToken}`,
             },
             body: {
-              score: "4:20",
+              score: 260,
               rx: false,
             },
           }
@@ -749,7 +749,7 @@ describe("/v1/workouts", () => {
         expect(res2.body).toHaveProperty("workout_id", workoutId);
         expect(res2.body).toHaveProperty("created_at");
         expect(res2.body).toHaveProperty("updated_at");
-        expect(res2.body).toHaveProperty("score", "4:20");
+        expect(res2.body).toHaveProperty("score", 260);
         expect(res2.body).toHaveProperty("rx", false);
 
         const res3: WorkoutResponse = await request.get(
@@ -769,7 +769,7 @@ describe("/v1/workouts", () => {
         expect(res3.body.scores[0]).toHaveProperty("workout_id", workoutId);
         expect(res3.body.scores[0]).toHaveProperty("created_at");
         expect(res3.body.scores[0]).toHaveProperty("updated_at");
-        expect(res3.body.scores[0]).toHaveProperty("score", "4:20");
+        expect(res3.body.scores[0]).toHaveProperty("score", 260);
         expect(res3.body.scores[0]).toHaveProperty("rx", false);
 
         const workoutScore = res3.body.scores[0];

--- a/src/models/movement.rs
+++ b/src/models/movement.rs
@@ -109,7 +109,7 @@ pub struct UpdateMovement {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateMovementScore {
-    pub score: String,
+    pub score: f64,
     #[serde(default = "default_as_one")]
     pub sets: u32,
     #[serde(default = "default_as_one")]
@@ -121,7 +121,7 @@ pub struct CreateMovementScore {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateMovementScore {
-    pub score: Option<String>,
+    pub score: Option<f64>,
     pub sets: Option<u32>,
     pub reps: Option<u32>,
     pub notes: Option<String>,
@@ -132,7 +132,7 @@ pub struct MovementScoreModel {
     pub movement_score_id: String,
     pub movement_id: String,
     pub user_id: String,
-    pub score: String,
+    pub score: f64,
     pub measurement: MovementMeasurement,
     pub sets: u32,
     pub reps: u32,
@@ -194,7 +194,7 @@ mod tests {
             movement_score_id: "1".to_string(),
             movement_id: "2".to_string(),
             user_id: "3".to_string(),
-            score: "100".to_string(),
+            score: 100.0,
             measurement: MovementMeasurement::Weight,
             sets: 1,
             reps: 1,
@@ -208,7 +208,7 @@ mod tests {
             "movement_score_id": "1",
             "movement_id": "2",
             "user_id": "3",
-            "score": "100",
+            "score": 100.0,
             "measurement": "weight",
             "sets": 1,
             "reps": 1,

--- a/src/models/workout.rs
+++ b/src/models/workout.rs
@@ -116,7 +116,7 @@ pub struct UpdateWorkout {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateWorkoutScore {
-    pub score: String,
+    pub score: f64,
     #[serde(default = "default_as_false")]
     pub rx: bool,
     #[serde(default = "default_as_empty_string")]
@@ -126,7 +126,7 @@ pub struct CreateWorkoutScore {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateWorkoutScore {
-    pub score: Option<String>,
+    pub score: Option<f64>,
     pub rx: Option<bool>,
     pub notes: Option<String>,
     pub created_at: Option<String>,
@@ -137,7 +137,7 @@ pub struct WorkoutScoreModel {
     pub workout_score_id: String,
     pub workout_id: String,
     pub user_id: String,
-    pub score: String,
+    pub score: f64,
     pub measurement: WorkoutMeasurement,
     pub rx: bool,
     pub notes: String,
@@ -199,7 +199,7 @@ mod tests {
             workout_score_id: "1".to_string(),
             workout_id: "2".to_string(),
             user_id: "3".to_string(),
-            score: "1:59".to_string(),
+            score: 119.0,
             measurement: WorkoutMeasurement::Time,
             rx: true,
             notes: "".to_string(),
@@ -212,7 +212,7 @@ mod tests {
             "workout_score_id": "1",
             "workout_id": "2",
             "user_id": "3",
-            "score": "1:59",
+            "score": 119.0,
             "measurement": "time",
             "rx": true,
             "notes": "",

--- a/src/utils/resources.rs
+++ b/src/utils/resources.rs
@@ -7,6 +7,51 @@ pub fn create_hash(s: &str) -> String {
     HEXLOWER.encode(actual.as_ref())
 }
 
+fn parse_num(s: &str) -> f64 {
+    let val = s.parse::<f64>().unwrap_or(0.0);
+    warn!("Parsing value '{}' to f64, got '{}'", s, val);
+    val
+}
+
+pub fn time_to_seconds(time: &str) -> f64 {
+    // split: HH:MM:SS
+    let mut split = time.split(':').collect::<Vec<&str>>();
+    // split: HH:SS
+    let sec = split.pop();
+
+    // Invalid / No time
+    if sec.is_none() {
+        return 0.0;
+    }
+    let mut seconds = parse_num(sec.unwrap());
+
+    match split.len() {
+        // case: SS
+        0 => {
+            seconds += 0.0;
+        }
+        // case: MM:SS
+        1 => {
+            let min = parse_num(split[0]);
+            seconds += min * 60.0;
+        }
+        // case: HH:MM:SS
+        2 => {
+            let hour = parse_num(split[0]);
+            let min = parse_num(split[1]);
+            seconds += hour * 60.0 * 60.0;
+            seconds += min * 60.0;
+        }
+        // case: whatever else
+        len => {
+            warn!("Weird format with len {}", len);
+            return 0.0;
+        }
+    }
+
+    seconds
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -23,5 +68,16 @@ mod tests {
             hash1,
             "c746ea7049f69b2e8f6f15c27fdfc1e2f397fab3c276e9c8a280d9619b9856e5"
         );
+    }
+
+    #[test]
+    fn test_time_to_seconds() {
+        assert_eq!(91.1, time_to_seconds("1:31.1"));
+        assert_eq!(119.0, time_to_seconds("1:59"));
+        assert_eq!(119.5, time_to_seconds("00:01:59.5"));
+        assert_eq!(30.0, time_to_seconds("30"));
+        assert_eq!(30.0, time_to_seconds("0:30"));
+        assert_eq!(30.0, time_to_seconds("00:00:30"));
+        assert_eq!(4523.0, time_to_seconds("01:15:23"));
     }
 }


### PR DESCRIPTION
Decided to go with pure number values instead of doing some weird stuff with sorting time strings. For workouts/movements that use a time duration, I implemented a function to transform that value into seconds. In the UI I can simply render that in the format of `HH:MM:SS`.