### PR TITLE
fix: fix bug with score parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,6 @@ dependencies = [
  "log",
  "mongodb",
  "oas3",
- "regex",
  "ring",
  "rusqlite",
  "serde 1.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ oas3 = "0.2.1"
 rusqlite = { version = "0.24.2", features = ["bundled", "blob"] }
 ring = "0.16.19"
 data-encoding = "2.3.1"
-regex = "1"
 
 [dev-dependencies]
 futures-await-test = "0.3.0"

--- a/src/services/mywod.rs
+++ b/src/services/mywod.rs
@@ -45,6 +45,7 @@ pub async fn save_workouts_and_scores(
     let mut added_scores = 0u32;
 
     for workout in workouts {
+        debug!("Processing workout '{}'", workout.title);
         let new_workout = CreateWorkout {
             name: workout.title.to_owned(),
             description: workout.description,
@@ -84,6 +85,7 @@ pub async fn save_workouts_and_scores(
         }
 
         if let Some(workout) = workout {
+            debug!("Processing scores for '{}", workout.name);
             let score_data = parse_workout_score(score);
             let added_score = workout_repo
                 .create_workout_score(user_id, &workout, score_data)


### PR DESCRIPTION
It was parsing rounds without additional reps in the score incorrectly, it removed the last digit from the value.